### PR TITLE
feat: time slider con reproducción automática

### DIFF
--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -6,3 +6,7 @@ El mapa colorea las provincias según el alquiler medio (€) del último año d
 npm i
 npm run dev
 ```
+
+## Interacción temporal: deslizador + play
+
+Ahora puedes elegir el año con un deslizador y reproducir la evolución automáticamente con el botón de play.

--- a/alquiler-dashboard/src/App.css
+++ b/alquiler-dashboard/src/App.css
@@ -40,3 +40,9 @@
 .read-the-docs {
   color: #888;
 }
+
+.time-slider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -4,28 +4,21 @@ import * as d3 from 'd3';
 import { interpolateRdYlBu } from 'd3-scale-chromatic';
 import Map from './components/Map';
 import Legend from './components/Legend';
+import TimeSlider from './components/TimeSlider';
 import useAlquilerData from './hooks/useAlquilerData';
 
 function App() {
-  const { records, years } = useAlquilerData();
-  const [year, setYear] = useState(null);
+  const { records, years, domainPrecio } = useAlquilerData();
+  const [year, setYear] = useState(years[years.length - 1]);
   useEffect(() => {
     if (years.length) {
-      setYear(years[years.length - 1]);
+      setYear(y => (y == null ? years[years.length - 1] : y));
     }
   }, [years]);
 
   const [provinciaSel, setProvinciaSel] = useState(null);
 
-  const domain = useMemo(() => {
-    const vals = records
-      .filter(
-        r => year != null && r.anio === year && r.Total != null && !Number.isNaN(+r.Total)
-      )
-
-      .map(r => +r.Total);
-    return [d3.min(vals), d3.max(vals)];
-  }, [records, year]);
+  const domain = useMemo(() => domainPrecio(year), [domainPrecio, year]);
 
   if (!records || year == null) return <p>Cargando datos…</p>;
 
@@ -33,6 +26,7 @@ function App() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
       <h1>Dashboard de alquileres</h1>
+      <TimeSlider years={years} year={year} setYear={setYear} />
       <Legend domain={domain} interpolator={interpolateRdYlBu} />
       <Map data={records} year={year} colorScaleDomain={domain} onSelect={setProvinciaSel} />
       {provinciaSel && <p>Provincia seleccionada: {provinciaSel}</p>}

--- a/alquiler-dashboard/src/components/TimeSlider.jsx
+++ b/alquiler-dashboard/src/components/TimeSlider.jsx
@@ -1,0 +1,59 @@
+import { useState, useRef, useEffect } from 'react';
+
+export default function TimeSlider({ years, year, setYear }) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const requestId = useRef(null);
+
+  const first = years[0];
+  const last = years[years.length - 1];
+
+  useEffect(() => {
+    return () => {
+      if (requestId.current) {
+        cancelAnimationFrame(requestId.current);
+      }
+    };
+  }, []);
+
+  const togglePlay = () => {
+    setIsPlaying(prev => {
+      const next = !prev;
+      if (next) {
+        const tick = () => {
+          setYear(prevYear => (prevYear === last ? first : prevYear + 1));
+          requestId.current = requestAnimationFrame(tick);
+        };
+        requestId.current = requestAnimationFrame(tick);
+      } else {
+        if (requestId.current) {
+          cancelAnimationFrame(requestId.current);
+        }
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="time-slider">
+      <button
+        onClick={togglePlay}
+        aria-label={isPlaying ? 'Pausar' : 'Reproducir'}
+        aria-pressed={isPlaying}
+      >
+        {isPlaying ? '⏸' : '▶'}
+      </button>
+      <input
+        type="range"
+        min={first}
+        max={last}
+        step="1"
+        value={year}
+        onChange={e => setYear(+e.target.value)}
+        aria-valuemin={first}
+        aria-valuemax={last}
+        aria-valuenow={year}
+      />
+      <span>{year}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TimeSlider component to control the year and play animation
- wire TimeSlider into App and compute domain with hook helper
- basic styling for the slider
- update README with new feature description

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e7883e9c8329aff2e515acd93ac2