### PR TITLE
feat: paleta gris→azul y tooltip legible

### DIFF
--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -2,7 +2,8 @@
 
 El mapa colorea las provincias según el Índice de Precios de Vivienda en Alquiler para cada provincia.
 
-Usamos la paleta Brewer **YlOrRd** de 7 pasos para resaltar mejor los cambios entre años.
+Usamos una paleta *Greys–Blues* de 7 clases para mayor contraste entre años.
+El tooltip muestra el texto en negro sobre fondo blanco para mejorar la accesibilidad.
 Los datos provienen del fichero "Índices provinciales: general y por tamaño de la vivienda" (tabla 59059 del INE). Se procesan con d3.dsv para normalizar valores numéricos y permiten seleccionar el **tamaño de la vivienda** (Total, <40 m², 40-80 m², >80 m²).
 
 Los nombres de provincia se obtienen a partir de su código INE.

--- a/alquiler-dashboard/src/components/Legend.jsx
+++ b/alquiler-dashboard/src/components/Legend.jsx
@@ -1,30 +1,29 @@
 export default function Legend({ scale }) {
 
   if (scale && typeof scale.invertExtent === 'function') {
-    const colors = scale.range();
-    const stepWidth = 20;
-    const last = scale.invertExtent(colors[colors.length - 1])[1];
+    const rects = scale.range();
+    const last = scale.invertExtent(rects[rects.length - 1])[1];
     return (
       <svg
-        width={colors.length * stepWidth}
-        height={20}
+        width={rects.length * 25}
+        height={24}
         aria-label="leyenda"
         role="img"
       >
-        {colors.map((c, i) => {
+        {rects.map((c, i) => {
           const [t0] = scale.invertExtent(c);
           return (
             <g key={c}>
-              <rect x={i * stepWidth} y={4} width={stepWidth} height={12} fill={c} />
-              <text x={i * stepWidth} y={18} fontSize={10} textAnchor="start">
+              <rect x={i * 25} width={24} height={12} fill={c} />
+              <text x={i * 25} y={22} fontSize={10} textAnchor="start">
                 {t0.toFixed ? t0.toFixed(0) : t0}
               </text>
             </g>
           );
         })}
         <text
-          x={colors.length * stepWidth}
-          y={18}
+          x={rects.length * 25}
+          y={22}
           fontSize={10}
           textAnchor="end"
         >

--- a/alquiler-dashboard/src/components/Map.jsx
+++ b/alquiler-dashboard/src/components/Map.jsx
@@ -22,6 +22,7 @@ export default function Map({ data, year, tam, colorScaleDomain, onSelect, selec
       .style('pointer-events', 'none')
       .style('opacity', 0)
       .style('background', '#fff')
+      .style('color', '#000')
       .style('border', '1px solid #ccc')
       .style('padding', '4px 8px')
       .style('border-radius', '4px');
@@ -50,7 +51,7 @@ export default function Map({ data, year, tam, colorScaleDomain, onSelect, selec
     tooltipRef.current
       .html(
         `<strong>${name}</strong><br/>${
-          val != null && !Number.isNaN(val) ? val.toFixed(1) + ' €' : 'Sin dato'
+          val != null && !Number.isNaN(val) ? val.toFixed(1) + ' pts' : 'Sin dato'
         }`
       )
       .style('left', `${event.pageX + 10}px`)

--- a/alquiler-dashboard/src/utils/colorScale.js
+++ b/alquiler-dashboard/src/utils/colorScale.js
@@ -1,6 +1,15 @@
 import { scaleQuantize } from 'd3-scale';
-import { schemeYlOrRd } from 'd3-scale-chromatic';
 
-export default function colorScale(domain) {
-  return scaleQuantize().domain(domain).range(schemeYlOrRd[7]);
+const greyBlue7 = [
+  '#f2f2f2',
+  '#e0e0e0',
+  '#c6d4e6',
+  '#9ebede',
+  '#6d9fd0',
+  '#397cb6',
+  '#08306b',
+];
+
+export default function createColorScale(domain) {
+  return scaleQuantize(domain, greyBlue7);
 }


### PR DESCRIPTION
## Summary
- update colorScale with greys-blues palette
- render quantized legend rectangles
- show tooltip text in black and display values in pts
- document new palette and tooltip accessibility

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f641e338832991be07ba27878e04