### PR TITLE
UI refresh – CSS Grid layout, dark cards, improved tooltip

### DIFF
--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -22,3 +22,8 @@ Ahora puedes elegir el año con un deslizador y reproducir la evolución automá
 Se incluye un treemap con el alquiler medio de cada comunidad autónoma.
 Al hacer clic en una región del treemap, el mapa se filtra y se grisarán
 las provincias que no pertenecen a la comunidad seleccionada.
+
+## Estilo y diseño
+
+La interfaz usa un *dashboard* oscuro con tarjetas y cuadrícula CSS Grid.
+![Captura del nuevo diseño](TODO)

--- a/alquiler-dashboard/package-lock.json
+++ b/alquiler-dashboard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "alquiler-dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "classnames": "^2.5.1",
         "d3": "^7.9.0",
         "d3-scale-chromatic": "^3.1.0",
         "es-atlas": "^0.6.0",
@@ -1569,6 +1570,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/alquiler-dashboard/package.json
+++ b/alquiler-dashboard/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "d3": "^7.9.0",
     "d3-scale-chromatic": "^3.1.0",
     "es-atlas": "^0.6.0",

--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -5,6 +5,7 @@ import Map from './components/Map';
 import Legend from './components/Legend';
 import TimeSlider from './components/TimeSlider';
 import Treemap from './components/Treemap';
+import './styles/dashboard.css';
 import useIndiceData from './hooks/useIndiceData';
 import provToCca from './utils/provToCca.js';
 import createColorScale from './utils/colorScale.js';
@@ -45,25 +46,43 @@ function App() {
 
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+    <div>
       <h1>Dashboard de alquileres</h1>
-      <TimeSlider years={years} year={year} setYear={setYear} />
-      <Legend scale={colorScale} />
-      <Treemap
-        data={aggByCca}
-        selectedCca={selectedCca}
-        onSelect={setSelectedCca}
-        colorDomain={colorDomain}
-      />
-      <Map
-        data={records}
-        year={year}
-        tam={tam}
-        colorScaleDomain={colorDomain}
-        onSelect={setProvinciaSel}
-        selectedCca={selectedCca}
-      />
-      {provinciaSel && <p>Provincia seleccionada: {provinciaSel}</p>}
+      <div className="controls">
+        <TimeSlider years={years} year={year} setYear={setYear} />
+      </div>
+
+      <div className="grid-dash">
+        <div className="card" role="region" aria-label="Leyenda de colores">
+          <Legend scale={colorScale} />
+        </div>
+        <div className="card" role="region" aria-label="Treemap por comunidad">
+          <Treemap
+            data={aggByCca}
+            selectedCca={selectedCca}
+            onSelect={setSelectedCca}
+            colorDomain={colorDomain}
+          />
+        </div>
+        <div
+          className="card"
+          style={{ gridColumn: '1 / span 2' }}
+          role="region"
+          aria-label="Mapa de alquileres por provincia"
+        >
+          <Map
+            data={records}
+            year={year}
+            tam={tam}
+            colorScaleDomain={colorDomain}
+            onSelect={setProvinciaSel}
+            selectedCca={selectedCca}
+          />
+        </div>
+      </div>
+      {provinciaSel && (
+        <footer>Provincia seleccionada: {provinciaSel}</footer>
+      )}
     </div>
   );
 }

--- a/alquiler-dashboard/src/components/Legend.jsx
+++ b/alquiler-dashboard/src/components/Legend.jsx
@@ -3,13 +3,15 @@ export default function Legend({ scale }) {
   if (scale && typeof scale.invertExtent === 'function') {
     const rects = scale.range();
     const last = scale.invertExtent(rects[rects.length - 1])[1];
+    const width = rects.length * 25;
     return (
-      <svg
-        width={rects.length * 25}
-        height={24}
-        aria-label="leyenda"
-        role="img"
-      >
+      <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+        <svg
+          width={width}
+          height={24}
+          aria-label="leyenda"
+          role="img"
+        >
         {rects.map((c, i) => {
           const [t0] = scale.invertExtent(c);
           return (
@@ -29,7 +31,8 @@ export default function Legend({ scale }) {
         >
           {last.toFixed ? last.toFixed(0) : last}
         </text>
-      </svg>
+        </svg>
+      </div>
     );
   }
 

--- a/alquiler-dashboard/src/components/Map.jsx
+++ b/alquiler-dashboard/src/components/Map.jsx
@@ -15,15 +15,16 @@ export default function Map({ data, year, tam, colorScaleDomain, onSelect, selec
   const [features, setFeatures] = useState(null);
 
   useEffect(() => {
-    const div = d3.select('#root')
+    const div = d3
+      .select('#root')
       .append('div')
       .attr('id', 'tooltip')
       .style('position', 'absolute')
       .style('pointer-events', 'none')
       .style('opacity', 0)
-      .style('background', '#fff')
-      .style('color', '#000')
-      .style('border', '1px solid #ccc')
+      .style('background', 'rgba(0,0,0,.8)')
+      .style('color', '#fff')
+      .style('border', 'none')
       .style('padding', '4px 8px')
       .style('border-radius', '4px');
     tooltipRef.current = div;
@@ -137,7 +138,7 @@ export default function Map({ data, year, tam, colorScaleDomain, onSelect, selec
   }, [draw]);
 
   return (
-    <div ref={containerRef} style={{ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT }}>
+    <div ref={containerRef} style={{ width: '100%', height: DEFAULT_HEIGHT }}>
       <svg ref={svgRef} width={DEFAULT_WIDTH} height={DEFAULT_HEIGHT} role="img" />
     </div>
   );

--- a/alquiler-dashboard/src/components/Treemap.jsx
+++ b/alquiler-dashboard/src/components/Treemap.jsx
@@ -35,7 +35,7 @@ function Treemap({ data, onSelect, selectedCca, colorDomain }) {
   return (
     <svg
       ref={ref}
-      width={300}
+      width="100%"
       height={300}
       role="img"
       aria-label="Treemap alquiler por CCAA"

--- a/alquiler-dashboard/src/styles/dashboard.css
+++ b/alquiler-dashboard/src/styles/dashboard.css
@@ -1,0 +1,31 @@
+:root {
+  --bg: #131313;
+  --card: #1e1e1e;
+  --card-border: #2a2a2a;
+  --accent: #6d9fd0;
+  --text: #eaeaea;
+  font-family: system-ui, 'Inter', sans-serif;
+}
+body { background: var(--bg); color: var(--text); }
+h1 { font-size: clamp(1.8rem, 3vw, 2.8rem); margin: .5rem 0 1rem; }
+.grid-dash {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-auto-rows: auto;
+  gap: 1rem;
+  padding: 0 1rem;
+}
+.card {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.6);
+  padding: .75rem;
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.card:hover { transform: translateY(-4px); box-shadow:0 4px 8px rgba(0,0,0,.6);}
+#tooltip {
+  background: rgba(0,0,0,.8) !important;
+  border: none !important;
+  color: #fff !important;
+}


### PR DESCRIPTION
## Summary
- add classnames dependency
- implement dark dashboard layout with CSS Grid
- center legend component and make treemap/map responsive
- darken tooltips
- document the new style

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849f72688448329a1a6e7748cb12b77