### PR TITLE
Add year range and size filters

### DIFF
--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -13,9 +13,9 @@ npm i
 npm run dev
 ```
 
-## Interacción temporal: deslizador + play
+## Controles
 
-Ahora puedes elegir el año con un deslizador y reproducir la evolución automáticamente con el botón de play.
+Puedes escoger el **tamaño de la vivienda** con un desplegable y filtrar los datos por un **rango de años** usando dos deslizadores. El intervalo seleccionado aparece junto a los controles.
 
 ## Vista agregada por CCAA
 

--- a/alquiler-dashboard/src/components/Map.jsx
+++ b/alquiler-dashboard/src/components/Map.jsx
@@ -8,7 +8,7 @@ import createColorScale from '../utils/colorScale.js';
 const DEFAULT_WIDTH = 700;
 const DEFAULT_HEIGHT = 550;
 
-export default function Map({ data, year, tam, colorScaleDomain, onSelect, selectedCca }) {
+export default function Map({ filtered, colorScaleDomain, onSelect, selectedCca }) {
   const containerRef = useRef(null);
   const svgRef = useRef(null);
   const tooltipRef = useRef(null);
@@ -51,8 +51,10 @@ export default function Map({ data, year, tam, colorScaleDomain, onSelect, selec
     const name = provinceNames[id] || `Provincia ${id}`;
     tooltipRef.current
       .html(
-        `<strong>${name}</strong><br/>${
-          val != null && !Number.isNaN(val) ? val.toFixed(1) + ' pts' : 'Sin dato'
+        `<strong>${name}</strong><br/>Índice: ${
+          val != null && !Number.isNaN(val)
+            ? val.toFixed(1).replace('.', ',')
+            : 'Sin dato'
         }`
       )
       .style('left', `${event.pageX + 10}px`)
@@ -82,14 +84,8 @@ export default function Map({ data, year, tam, colorScaleDomain, onSelect, selec
     projection.fitSize([width, height], { type: 'FeatureCollection', features });
 
     const values = d3.rollup(
-      data.filter(
-        d =>
-          d.anio === year &&
-          d.tamano === tam &&
-          d.indice != null &&
-          !Number.isNaN(d.indice)
-      ),
-      v => d3.mean(v, d => d.indice),
+      filtered.filter(d => d.valor != null && !Number.isNaN(d.valor)),
+      v => d3.mean(v, d => d.valor),
       d => d.cod_provincia
     );
 
@@ -127,7 +123,7 @@ export default function Map({ data, year, tam, colorScaleDomain, onSelect, selec
         const val = values.get(d.id);
         return val != null ? color(val) : '#ccc';
       });
-  }, [features, data, year, tam, colorScale, onSelect, selectedCca]);
+  }, [features, filtered, colorScale, onSelect, selectedCca]);
 
   useEffect(draw, [draw]);
 

--- a/alquiler-dashboard/src/hooks/useIndiceData.js
+++ b/alquiler-dashboard/src/hooks/useIndiceData.js
@@ -4,64 +4,43 @@ import * as d3 from 'd3';
 const DATA_URL = '/src/data/indices_provinciales.csv';
 
 export default function useIndiceData() {
-  const [records, setRecords] = useState(null);
+  const [records, setRecords] = useState([]);
 
   useEffect(() => {
-    d3.dsv(';', DATA_URL, d => {
-      const cleaned = {};
-      for (const key in d) {
-        if (!Object.prototype.hasOwnProperty.call(d, key)) continue;
-        let val = d[key];
-        if (typeof val === 'string') {
-          val = val.trim().replace(',', '.');
-          if (val === '' || val === '..') val = NaN;
-        }
-        const num = +val;
-        cleaned[key] = Number.isNaN(num) ? val : num;
-      }
-      cleaned.anio = +cleaned.Periodo;
-      if (d.Provincias) {
-        const [cod, ...rest] = d.Provincias.split(' ');
-        cleaned.cod_provincia = cod ? cod.padStart(2, '0') : null;
-        cleaned.provincia = rest.join(' ');
-      }
-      cleaned.tamano = d['Tamaño de la vivienda'];
-      cleaned.indice = +cleaned.Total;
-      return cleaned;
-    }).then(data => setRecords(data));
+    d3.dsv(';', DATA_URL, row => ({
+      anio: +row.Periodo,
+      tam: row['Tamaño de la vivienda'],
+      cod_provincia: (row.Provincias.match(/^\d{2}/) ?? ['00'])[0],
+      valor: +row.Total.replace(',', '.'),
+    })).then(data => setRecords(data));
   }, []);
 
   const years = useMemo(() => {
-    if (!records) return [];
-    return Array.from(new Set(records.map(d => d.anio))).sort((a, b) => a - b);
+    if (!records.length) return [];
+    const min = d3.min(records, d => d.anio);
+    const max = d3.max(records, d => d.anio);
+    const out = [];
+    for (let y = min; y <= max; y++) out.push(y);
+    return out;
   }, [records]);
 
-  const provincias = useMemo(() => {
-    if (!records) return [];
-    return Array.from(
-      new Set(records.map(d => d.cod_provincia).filter(Boolean))
-    ).sort();
-  }, [records]);
-
-  const tamanoOptions = useMemo(() => {
-    if (!records) return [];
-    return Array.from(new Set(records.map(d => d.tamano)));
-  }, [records]);
-
-  const domain = useCallback(
-    (anio, tam) => {
-      if (!records) return [NaN, NaN];
-      const values = records
-        .filter(r => r.anio === anio && r.tamano === tam)
-        .map(r => r.indice)
-        .filter(v => !Number.isNaN(v));
-      return d3.extent(values);
-    },
+  const sizeOptions = useMemo(
+    () => Array.from(new Set(records.map(d => d.tam))),
     [records]
   );
 
-  return useMemo(
-    () => ({ records: records || [], years, provincias, tamanoOptions, domain }),
-    [records, years, provincias, tamanoOptions, domain]
+  const getFiltered = useCallback(
+    ({ from, to, size }) =>
+      records.filter(
+        d => d.anio >= from && d.anio <= to && d.tam === size
+      ),
+    [records]
   );
+
+  const domain = useCallback(filtered => {
+    const vals = filtered.map(d => d.valor).filter(v => !Number.isNaN(v));
+    return d3.extent(vals);
+  }, []);
+
+  return { records, years, sizeOptions, getFiltered, domain };
 }


### PR DESCRIPTION
## Summary
- implement new `useIndiceData` hook
- add controls for size and year range
- adjust `Map` and `Treemap` to use filtered data
- update tooltip formatting
- document controls in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a14d0e3808329b26d951773c4e994