### PR TITLE
Fix build base path for standalone usage

### DIFF
--- a/alquiler-dashboard/vite.config.js
+++ b/alquiler-dashboard/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // Permite servir la versión de producción desde
+  // un directorio sin ruta base fija
+  base: './',
 })


### PR DESCRIPTION
## Summary
- configure `vite.config.js` to use a relative base path

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a1b5d0e108329b96327858b216e7a