### PR TITLE
Fix treemap NaN tooltip and add keys

### DIFF
--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -70,10 +70,10 @@ function App() {
       </div>
 
       <div className="grid-dash">
-        <div className="card" role="region" aria-label="Leyenda de colores">
+        <div className="card" role="region" aria-label="Leyenda de colores" key="legend">
           <Legend scale={colorScale} />
         </div>
-        <div className="card" role="region" aria-label="Treemap por comunidad">
+        <div className="card" role="region" aria-label="Treemap por comunidad" key="treemap">
           <Treemap
             filtered={filtered}
             selectedCca={selectedCca}
@@ -86,6 +86,7 @@ function App() {
           style={{ gridColumn: '1 / span 2' }}
           role="region"
           aria-label="Mapa de alquileres por provincia"
+          key="map"
         >
           <Map
             filtered={filtered}

--- a/alquiler-dashboard/src/components/Treemap.jsx
+++ b/alquiler-dashboard/src/components/Treemap.jsx
@@ -41,14 +41,19 @@ function Treemap({ filtered, onSelect, selectedCca, colorDomain }) {
       .selectAll('title')
       .data(d => [d])
       .join('title')
-      .text(
-        d =>
-          `${ccaNames[d.data.cca]}: ${d.data.alquiler
-            .toFixed(1)
-            .replace('.', ',')} - ${d.data.euros
-            ?.toFixed(0)
-            .replace('.', ',')} €`
-      );
+      .text(d => {
+        const v = d.data.alquiler;
+        const euros = d.data.euros;
+        const vText =
+          v != null && !Number.isNaN(v)
+            ? v.toFixed(1).replace('.', ',')
+            : 'sin dato';
+        const eText =
+          euros != null && !Number.isNaN(euros)
+            ? euros.toFixed(0).replace('.', ',')
+            : 'sin dato';
+        return `${ccaNames[d.data.cca]}: ${vText} - ${eText} €`;
+      });
   }, [filtered, selectedCca, colorDomain, onSelect]);
 
   return (


### PR DESCRIPTION
## Summary
- avoid NaN in treemap tooltip when data is missing
- add stable keys to dashboard cards

## Testing
- `npm run lint`
- `npm run build`
- `timeout 5 npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684a1dca6b808329892e22f015b59529