### PR TITLE
Fix INE CSV column name encoding

### DIFF
--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -9,6 +9,7 @@ Los datos provienen del fichero "Índices provinciales: general y por tamaño de
 Los nombres de provincia se obtienen a partir de su código INE.
 
 Los CSV se sirven desde `/public`; Vite los copia tal cual a producción.
+El CSV original está en ISO-8859-1; la ñ aparece como `�`. El hook corrige el nombre de columna al vuelo.
 
 ```bash
 npm i


### PR DESCRIPTION
## Summary
- decode misencoded `Tamaño de la vivienda` column when parsing CSV
- log parsed record counts for manual verification
- sort size selector options
- document ISO-8859-1 CSV quirk in dashboard README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a2c4c10fc8329acb9e9d702a97c37