### PR TITLE
Implement two-thumb year slider and map layout

### DIFF
--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -18,7 +18,7 @@ npm run dev
 
 ## Controles
 
-Puedes escoger el **tamaño de la vivienda** con un desplegable y filtrar los datos por un **rango de años** usando dos deslizadores. El intervalo seleccionado aparece junto a los controles.
+Puedes escoger el **tamaño de la vivienda** con un desplegable y filtrar los datos por un **rango de años** mediante un deslizador de rango doble. El intervalo seleccionado aparece junto a los controles.
 
 ## Vista agregada por CCAA
 
@@ -30,3 +30,5 @@ las provincias que no pertenecen a la comunidad seleccionada.
 
 La interfaz usa un *dashboard* oscuro con tarjetas y cuadrícula CSS Grid.
 ![Captura del nuevo diseño](TODO)
+
+Nuevo selector de años con doble asa, mapa anclado a la derecha.

--- a/alquiler-dashboard/package-lock.json
+++ b/alquiler-dashboard/package-lock.json
@@ -14,6 +14,7 @@
         "es-atlas": "^0.6.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-range": "^1.10.0",
         "topojson-client": "^3.1.0"
       },
       "devDependencies": {
@@ -2916,6 +2917,16 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-range": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.10.0.tgz",
+      "integrity": "sha512-kDo0LiBUHIQIP8menx0UoxTnHr7UXBYpIYl/DR9jCaO1o29VwvCLpkP/qOTNQz5hkJadPg1uEM07XJcJ1XGoKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/alquiler-dashboard/package.json
+++ b/alquiler-dashboard/package.json
@@ -16,6 +16,7 @@
     "es-atlas": "^0.6.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-range": "^1.10.0",
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {

--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
+import { Range } from 'react-range';
 
 import Map from './components/Map';
 import Legend from './components/Legend';
@@ -14,6 +15,51 @@ function App() {
   const [from, setFrom] = useState(minYear);
   const [to, setTo] = useState(maxYear);
   const [size, setSize] = useState('Total');
+
+  const STEP = 1;
+  const MIN = minYear;
+  const MAX = maxYear;
+
+  function YearRange({ values, onChange }) {
+    return (
+      <Range
+        values={values}
+        step={STEP}
+        min={MIN}
+        max={MAX}
+        onChange={onChange}
+        renderTrack={({ props, children }) => (
+          <div
+            {...props}
+            style={{
+              ...props.style,
+              height: '4px',
+              background: '#555',
+              margin: '0 0.5rem',
+            }}
+          >
+            {children}
+          </div>
+        )}
+        renderThumb={({ props }) => (
+          <div
+            {...props}
+            aria-valuemin={MIN}
+            aria-valuemax={MAX}
+            aria-valuenow={values[props.key]}
+            style={{
+              ...props.style,
+              height: '16px',
+              width: '16px',
+              borderRadius: '50%',
+              backgroundColor: '#90caf9',
+              outline: 'none',
+            }}
+          />
+        )}
+      />
+    );
+  }
 
   useEffect(() => {
     if (years.length) {
@@ -51,30 +97,21 @@ function App() {
           ))}
         </select>
         <label>Años:</label>
-        <input
-          type="range"
-          min={minYear}
-          max={maxYear}
-          value={from}
-          onChange={e => setFrom(+e.target.value)}
-          aria-label="Desde"
+        <YearRange
+          values={[from, to]}
+          onChange={([f, t]) => {
+            setFrom(f);
+            setTo(t);
+          }}
         />
-        <input
-          type="range"
-          min={minYear}
-          max={maxYear}
-          value={to}
-          onChange={e => setTo(+e.target.value)}
-          aria-label="Hasta"
-        />
-        <span>{from}-{to}</span>
+        <span>{from} – {to}</span>
       </div>
 
       <div className="grid-dash">
-        <div className="card" role="region" aria-label="Leyenda de colores" key="legend">
+        <div className="card legend" role="region" aria-label="Leyenda de colores" key="legend">
           <Legend scale={colorScale} />
         </div>
-        <div className="card" role="region" aria-label="Treemap por comunidad" key="treemap">
+        <div className="card treemap" role="region" aria-label="Treemap por comunidad" key="treemap">
           <Treemap
             filtered={filtered}
             selectedCca={selectedCca}
@@ -84,7 +121,6 @@ function App() {
         </div>
         <div
           className="card map"
-          style={{ gridColumn: '1 / span 2' }}
           role="region"
           aria-label="Mapa de alquileres por provincia"
           key="map"

--- a/alquiler-dashboard/src/styles/dashboard.css
+++ b/alquiler-dashboard/src/styles/dashboard.css
@@ -32,3 +32,19 @@ h1 { font-size: clamp(1.8rem, 3vw, 2.8rem); margin: .5rem 0 1rem; }
 
 .card.map { min-height: 500px; }
 .card.map svg { width: 100%; height: 100%; }
+
+@media (min-width: 768px) {
+  .grid-dash {
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    grid-template-areas:
+      "legend  map"
+      "treemap map"
+      "parallel map";
+    gap: 1rem;
+  }
+  .card.legend { grid-area: legend; }
+  .card.treemap { grid-area: treemap; }
+  .card.parallel { grid-area: parallel; }
+  .card.map { grid-area: map; }
+}


### PR DESCRIPTION
## Summary
- replace dual sliders with two-thumb `react-range` slider
- anchor map column with CSS grid areas
- add new dependency `react-range`
- mention new slider and layout in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a2ee9d714832993a270f02dfdb3a0