### PR TITLE
Show map filtered by year and size

### DIFF
--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -1,89 +1,21 @@
-import { useState, useMemo, useEffect } from 'react';
-import { Range } from 'react-range';
+import { useState } from 'react';
 
 import Map from './components/Map';
-import Legend from './components/Legend';
-import Treemap from './components/Treemap';
 import './styles/dashboard.css';
 import useIndiceData from './hooks/useIndiceData';
-import createColorScale from './utils/colorScale.js';
 
 function App() {
-  const { records, years, sizeOptions, getFiltered } = useIndiceData();
+  const { records, years, sizeOptions, getByYearSize, domainEuros } =
+    useIndiceData();
   const minYear = years[0];
   const maxYear = years[years.length - 1];
-  const [from, setFrom] = useState(minYear);
-  const [to, setTo] = useState(maxYear);
+  const [year, setYear] = useState(maxYear);
   const [size, setSize] = useState('Total');
 
-  const STEP = 1;
-  const MIN = minYear;
-  const MAX = maxYear;
-
-  function YearRange({ values, onChange }) {
-    return (
-      <Range
-        values={values}
-        step={STEP}
-        min={MIN}
-        max={MAX}
-        onChange={onChange}
-        renderTrack={({ props, children }) => (
-          <div
-            {...props}
-            style={{
-              ...props.style,
-              height: '4px',
-              background: '#555',
-              margin: '0 0.5rem',
-            }}
-          >
-            {children}
-          </div>
-        )}
-        renderThumb={({ props }) => (
-          <div
-            {...props}
-            aria-valuemin={MIN}
-            aria-valuemax={MAX}
-            aria-valuenow={values[props.key]}
-            style={{
-              ...props.style,
-              height: '16px',
-              width: '16px',
-              borderRadius: '50%',
-              backgroundColor: '#90caf9',
-              outline: 'none',
-            }}
-          />
-        )}
-      />
-    );
-  }
-
-  useEffect(() => {
-    if (years.length) {
-      setFrom(y => (y == null ? minYear : y));
-      setTo(t => (t == null ? maxYear : t));
-    }
-  }, [years, minYear, maxYear]);
-
-  const [provinciaSel, setProvinciaSel] = useState(null);
-  const [selectedCca, setSelectedCca] = useState(null);
-
-  const filtered = useMemo(
-    () => getFiltered({ from, to, size }),
-    [getFiltered, from, to, size]
-  );
-  const vals = filtered.map(d => d.valor);
-  const colorDomain = vals.length ? [Math.min(...vals), Math.max(...vals)] : [0, 1];
-  const colorScale = useMemo(
-    () => (colorDomain ? createColorScale(colorDomain) : null),
-    [colorDomain]
-  );
+  const filtered = getByYearSize(year, size);
+  const euroDomain = domainEuros(year, size);
 
   if (!records.length) return <p>Cargando datos…</p>;
-
 
   return (
     <div>
@@ -91,51 +23,32 @@ function App() {
       <div className="controls">
         <label>Tamaño:</label>
         <select value={size} onChange={e => setSize(e.target.value)}>
-          <option value="Total">Total</option>
           {sizeOptions.map(o => (
             <option key={o}>{o}</option>
           ))}
         </select>
-        <label>Años:</label>
-        <YearRange
-          values={[from, to]}
-          onChange={([f, t]) => {
-            setFrom(f);
-            setTo(t);
-          }}
+        <label>Año:</label>
+        <input
+          type="range"
+          min={minYear}
+          max={maxYear}
+          value={year}
+          onChange={e => setYear(+e.target.value)}
         />
-        <span>{from} – {to}</span>
+        <span>{year}</span>
       </div>
-
       <div className="grid-dash">
-        <div className="card legend" role="region" aria-label="Leyenda de colores" key="legend">
-          <Legend scale={colorScale} />
-        </div>
-        <div className="card treemap" role="region" aria-label="Treemap por comunidad" key="treemap">
-          <Treemap
-            filtered={filtered}
-            selectedCca={selectedCca}
-            onSelect={setSelectedCca}
-            colorDomain={colorDomain}
-          />
-        </div>
+        {/* <div className="card legend" role="region" aria-label="Leyenda de colores" key="legend"></div> */}
+        {/* <div className="card treemap" role="region" aria-label="Treemap por comunidad" key="treemap"></div> */}
         <div
           className="card map"
           role="region"
           aria-label="Mapa de alquileres por provincia"
           key="map"
         >
-          <Map
-            filtered={filtered}
-            colorScaleDomain={colorDomain}
-            onSelect={setProvinciaSel}
-            selectedCca={selectedCca}
-          />
+          <Map filtered={filtered} euroDomain={euroDomain} />
         </div>
       </div>
-      {provinciaSel && (
-        <footer>Provincia seleccionada: {provinciaSel}</footer>
-      )}
     </div>
   );
 }

--- a/alquiler-dashboard/src/hooks/useIndiceData.js
+++ b/alquiler-dashboard/src/hooks/useIndiceData.js
@@ -79,5 +79,26 @@ export default function useIndiceData() {
     return d3.extent(vals);
   }, []);
 
-  return { records, years, sizeOptions, getFiltered, domain };
+  const getByYearSize = useCallback(
+    (year, size) => records.filter(d => d.anio === year && d.tam === size),
+    [records]
+  );
+
+  const domainEuros = useCallback(
+    (year, size) => {
+      const filtered = getByYearSize(year, size);
+      return d3.extent(filtered, d => d.euros);
+    },
+    [getByYearSize]
+  );
+
+  return {
+    records,
+    years,
+    sizeOptions,
+    getFiltered,
+    domain,
+    getByYearSize,
+    domainEuros,
+  };
 }


### PR DESCRIPTION
## Summary
- support filtering data by year and size in `useIndiceData`
- simplify dashboard to map only, with a single year slider
- recolor map using a sequential scale for average €/m²

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a3060fa3083298f6edf6a0e95cfb9