### PR TITLE
feat: mapa €/m² usando ALQM2_LV_M_VC (MITMA)

### DIFF
--- a/alquiler-dashboard/package-lock.json
+++ b/alquiler-dashboard/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "alquiler-dashboard",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "classnames": "^2.5.1",
+        "csv-parse": "^5.5.4",
         "d3": "^7.9.0",
         "d3-scale-chromatic": "^3.1.0",
         "es-atlas": "^0.6.0",
@@ -1641,6 +1643,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
       "license": "MIT"
     },
     "node_modules/d3": {

--- a/alquiler-dashboard/package.json
+++ b/alquiler-dashboard/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "node scripts/mitma_pivot.mjs"
   },
   "dependencies": {
     "classnames": "^2.5.1",
@@ -17,7 +18,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-range": "^1.10.0",
-    "topojson-client": "^3.1.0"
+    "topojson-client": "^3.1.0",
+    "csv-parse": "^5.5.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/alquiler-dashboard/public/alquiler_euros_prov_2011_2023.csv
+++ b/alquiler-dashboard/public/alquiler_euros_prov_2011_2023.csv
@@ -1,0 +1,628 @@
+cod_provincia,provincia,anio,euros_m2
+02,Albacete,2011,4.4
+02,Albacete,2012,4.3
+02,Albacete,2013,4.1
+02,Albacete,2014,4
+02,Albacete,2015,4
+02,Albacete,2016,4.1
+02,Albacete,2017,4.1
+02,Albacete,2018,4.2
+02,Albacete,2019,4.5
+02,Albacete,2020,4.5
+02,Albacete,2021,4.7
+02,Albacete,2022,4.9
+02,Albacete,2023,5.1
+03,Alicante,2011,4.5
+03,Alicante,2012,4.4
+03,Alicante,2013,4.2
+03,Alicante,2014,4.2
+03,Alicante,2015,4.2
+03,Alicante,2016,4.3
+03,Alicante,2017,4.4
+03,Alicante,2018,4.5
+03,Alicante,2019,4.9
+03,Alicante,2020,5
+03,Alicante,2021,5.2
+03,Alicante,2022,5.5
+03,Alicante,2023,5.8
+04,Almería,2011,4.8
+04,Almería,2012,4.5
+04,Almería,2013,4.3
+04,Almería,2014,4.2
+04,Almería,2015,4.1
+04,Almería,2016,4.2
+04,Almería,2017,4.3
+04,Almería,2018,4.4
+04,Almería,2019,4.7
+04,Almería,2020,4.9
+04,Almería,2021,5.1
+04,Almería,2022,5.3
+04,Almería,2023,5.6
+05,Ávila,2011,4.3
+05,Ávila,2012,4.1
+05,Ávila,2013,3.8
+05,Ávila,2014,3.8
+05,Ávila,2015,3.7
+05,Ávila,2016,3.8
+05,Ávila,2017,3.8
+05,Ávila,2018,3.9
+05,Ávila,2019,4.2
+05,Ávila,2020,4.3
+05,Ávila,2021,4.5
+05,Ávila,2022,4.7
+05,Ávila,2023,5
+06,Badajoz,2011,4.1
+06,Badajoz,2012,4.1
+06,Badajoz,2013,4
+06,Badajoz,2014,3.9
+06,Badajoz,2015,3.9
+06,Badajoz,2016,3.9
+06,Badajoz,2017,4
+06,Badajoz,2018,4.1
+06,Badajoz,2019,4.3
+06,Badajoz,2020,4.4
+06,Badajoz,2021,4.5
+06,Badajoz,2022,4.7
+06,Badajoz,2023,4.9
+07,Balears, Illes,2011,6.1
+07,Balears, Illes,2012,6
+07,Balears, Illes,2013,5.9
+07,Balears, Illes,2014,5.9
+07,Balears, Illes,2015,6.1
+07,Balears, Illes,2016,6.3
+07,Balears, Illes,2017,6.5
+07,Balears, Illes,2018,7
+07,Balears, Illes,2019,7.7
+07,Balears, Illes,2020,7.8
+07,Balears, Illes,2021,8.1
+07,Balears, Illes,2022,8.6
+07,Balears, Illes,2023,9.1
+08,Barcelona,2011,8.3
+08,Barcelona,2012,8.1
+08,Barcelona,2013,7.7
+08,Barcelona,2014,7.5
+08,Barcelona,2015,7.6
+08,Barcelona,2016,7.8
+08,Barcelona,2017,8
+08,Barcelona,2018,8.5
+08,Barcelona,2019,9.2
+08,Barcelona,2020,9.5
+08,Barcelona,2021,9.8
+08,Barcelona,2022,10.1
+08,Barcelona,2023,10.6
+09,Burgos,2011,5.6
+09,Burgos,2012,5.5
+09,Burgos,2013,5.2
+09,Burgos,2014,5.1
+09,Burgos,2015,5.1
+09,Burgos,2016,5.2
+09,Burgos,2017,5.2
+09,Burgos,2018,5.4
+09,Burgos,2019,5.7
+09,Burgos,2020,5.8
+09,Burgos,2021,6
+09,Burgos,2022,6.2
+09,Burgos,2023,6.4
+10,Cáceres,2011,3.8
+10,Cáceres,2012,3.8
+10,Cáceres,2013,3.7
+10,Cáceres,2014,3.6
+10,Cáceres,2015,3.5
+10,Cáceres,2016,3.6
+10,Cáceres,2017,3.7
+10,Cáceres,2018,3.7
+10,Cáceres,2019,3.9
+10,Cáceres,2020,4
+10,Cáceres,2021,4.1
+10,Cáceres,2022,4.3
+10,Cáceres,2023,4.5
+11,Cádiz,2011,5.5
+11,Cádiz,2012,5.4
+11,Cádiz,2013,5.3
+11,Cádiz,2014,5.2
+11,Cádiz,2015,5.1
+11,Cádiz,2016,5.2
+11,Cádiz,2017,5.3
+11,Cádiz,2018,5.4
+11,Cádiz,2019,5.8
+11,Cádiz,2020,6
+11,Cádiz,2021,6.2
+11,Cádiz,2022,6.5
+11,Cádiz,2023,6.8
+12,Castellón/Castelló,2011,3.8
+12,Castellón/Castelló,2012,3.7
+12,Castellón/Castelló,2013,3.5
+12,Castellón/Castelló,2014,3.4
+12,Castellón/Castelló,2015,3.4
+12,Castellón/Castelló,2016,3.4
+12,Castellón/Castelló,2017,3.5
+12,Castellón/Castelló,2018,3.6
+12,Castellón/Castelló,2019,3.9
+12,Castellón/Castelló,2020,4.1
+12,Castellón/Castelló,2021,4.3
+12,Castellón/Castelló,2022,4.5
+12,Castellón/Castelló,2023,4.8
+13,Ciudad Real,2011,4.5
+13,Ciudad Real,2012,4.4
+13,Ciudad Real,2013,4.1
+13,Ciudad Real,2014,4
+13,Ciudad Real,2015,3.9
+13,Ciudad Real,2016,3.9
+13,Ciudad Real,2017,4
+13,Ciudad Real,2018,4
+13,Ciudad Real,2019,4.3
+13,Ciudad Real,2020,4.4
+13,Ciudad Real,2021,4.5
+13,Ciudad Real,2022,4.6
+13,Ciudad Real,2023,4.8
+14,Córdoba,2011,5.2
+14,Córdoba,2012,5.2
+14,Córdoba,2013,5
+14,Córdoba,2014,4.9
+14,Córdoba,2015,4.9
+14,Córdoba,2016,5
+14,Córdoba,2017,5.1
+14,Córdoba,2018,5.1
+14,Córdoba,2019,5.6
+14,Córdoba,2020,5.6
+14,Córdoba,2021,5.7
+14,Córdoba,2022,5.9
+14,Córdoba,2023,6.1
+15,Coruña, A,2011,4.7
+15,Coruña, A,2012,4.7
+15,Coruña, A,2013,4.5
+15,Coruña, A,2014,4.5
+15,Coruña, A,2015,4.5
+15,Coruña, A,2016,4.5
+15,Coruña, A,2017,4.6
+15,Coruña, A,2018,4.7
+15,Coruña, A,2019,4.9
+15,Coruña, A,2020,5
+15,Coruña, A,2021,5.2
+15,Coruña, A,2022,5.4
+15,Coruña, A,2023,5.7
+16,Cuenca,2011,4.8
+16,Cuenca,2012,4.5
+16,Cuenca,2013,4.2
+16,Cuenca,2014,4
+16,Cuenca,2015,3.9
+16,Cuenca,2016,3.9
+16,Cuenca,2017,3.9
+16,Cuenca,2018,4
+16,Cuenca,2019,4.2
+16,Cuenca,2020,4.3
+16,Cuenca,2021,4.5
+16,Cuenca,2022,4.7
+16,Cuenca,2023,5
+17,Girona,2011,5.8
+17,Girona,2012,5.6
+17,Girona,2013,5.4
+17,Girona,2014,5.3
+17,Girona,2015,5.3
+17,Girona,2016,5.4
+17,Girona,2017,5.6
+17,Girona,2018,5.7
+17,Girona,2019,6.2
+17,Girona,2020,6.3
+17,Girona,2021,6.5
+17,Girona,2022,6.8
+17,Girona,2023,7.1
+18,Granada,2011,4.6
+18,Granada,2012,4.5
+18,Granada,2013,4.3
+18,Granada,2014,4.3
+18,Granada,2015,4.2
+18,Granada,2016,4.4
+18,Granada,2017,4.4
+18,Granada,2018,4.6
+18,Granada,2019,5
+18,Granada,2020,5.1
+18,Granada,2021,5.3
+18,Granada,2022,5.6
+18,Granada,2023,5.9
+19,Guadalajara,2011,5.9
+19,Guadalajara,2012,5.6
+19,Guadalajara,2013,5.2
+19,Guadalajara,2014,4.9
+19,Guadalajara,2015,4.9
+19,Guadalajara,2016,4.9
+19,Guadalajara,2017,5
+19,Guadalajara,2018,5.2
+19,Guadalajara,2019,5.6
+19,Guadalajara,2020,5.9
+19,Guadalajara,2021,6.1
+19,Guadalajara,2022,6.4
+19,Guadalajara,2023,6.7
+21,Huelva,2011,4.9
+21,Huelva,2012,4.8
+21,Huelva,2013,4.5
+21,Huelva,2014,4.4
+21,Huelva,2015,4.4
+21,Huelva,2016,4.5
+21,Huelva,2017,4.5
+21,Huelva,2018,4.7
+21,Huelva,2019,5
+21,Huelva,2020,5.2
+21,Huelva,2021,5.3
+21,Huelva,2022,5.6
+21,Huelva,2023,5.9
+22,Huesca,2011,4.6
+22,Huesca,2012,4.4
+22,Huesca,2013,4.3
+22,Huesca,2014,4.3
+22,Huesca,2015,4.2
+22,Huesca,2016,4.3
+22,Huesca,2017,4.4
+22,Huesca,2018,4.5
+22,Huesca,2019,4.9
+22,Huesca,2020,5
+22,Huesca,2021,5.2
+22,Huesca,2022,5.4
+22,Huesca,2023,5.6
+23,Jaén,2011,3.8
+23,Jaén,2012,3.7
+23,Jaén,2013,3.6
+23,Jaén,2014,3.6
+23,Jaén,2015,3.5
+23,Jaén,2016,3.6
+23,Jaén,2017,3.7
+23,Jaén,2018,3.7
+23,Jaén,2019,3.9
+23,Jaén,2020,4
+23,Jaén,2021,4.1
+23,Jaén,2022,4.2
+23,Jaén,2023,4.3
+24,León,2011,4
+24,León,2012,4
+24,León,2013,4
+24,León,2014,4
+24,León,2015,4
+24,León,2016,4.1
+24,León,2017,4.1
+24,León,2018,4.2
+24,León,2019,4.4
+24,León,2020,4.5
+24,León,2021,4.6
+24,León,2022,4.8
+24,León,2023,5
+25,Lleida,2011,4.6
+25,Lleida,2012,4.4
+25,Lleida,2013,4.2
+25,Lleida,2014,4.2
+25,Lleida,2015,4.2
+25,Lleida,2016,4.2
+25,Lleida,2017,4.3
+25,Lleida,2018,4.4
+25,Lleida,2019,4.7
+25,Lleida,2020,4.8
+25,Lleida,2021,5
+25,Lleida,2022,5.2
+25,Lleida,2023,5.5
+26,Rioja, La,2011,4.9
+26,Rioja, La,2012,4.7
+26,Rioja, La,2013,4.4
+26,Rioja, La,2014,4.3
+26,Rioja, La,2015,4.3
+26,Rioja, La,2016,4.4
+26,Rioja, La,2017,4.5
+26,Rioja, La,2018,4.5
+26,Rioja, La,2019,4.9
+26,Rioja, La,2020,5
+26,Rioja, La,2021,5.2
+26,Rioja, La,2022,5.4
+26,Rioja, La,2023,5.6
+27,Lugo,2011,3.2
+27,Lugo,2012,3.2
+27,Lugo,2013,3.2
+27,Lugo,2014,3.1
+27,Lugo,2015,3.1
+27,Lugo,2016,3.2
+27,Lugo,2017,3.3
+27,Lugo,2018,3.3
+27,Lugo,2019,3.6
+27,Lugo,2020,3.6
+27,Lugo,2021,3.7
+27,Lugo,2022,3.8
+27,Lugo,2023,4
+28,Madrid,2011,9.6
+28,Madrid,2012,9.3
+28,Madrid,2013,8.7
+28,Madrid,2014,8.5
+28,Madrid,2015,8.5
+28,Madrid,2016,8.7
+28,Madrid,2017,8.9
+28,Madrid,2018,9.3
+28,Madrid,2019,10.2
+28,Madrid,2020,10.4
+28,Madrid,2021,10.7
+28,Madrid,2022,11.1
+28,Madrid,2023,11.5
+29,Málaga,2011,6.1
+29,Málaga,2012,5.9
+29,Málaga,2013,5.7
+29,Málaga,2014,5.6
+29,Málaga,2015,5.6
+29,Málaga,2016,5.8
+29,Málaga,2017,6
+29,Málaga,2018,6.3
+29,Málaga,2019,7
+29,Málaga,2020,7.2
+29,Málaga,2021,7.5
+29,Málaga,2022,7.9
+29,Málaga,2023,8.4
+30,Murcia,2011,4.2
+30,Murcia,2012,4.1
+30,Murcia,2013,3.9
+30,Murcia,2014,3.8
+30,Murcia,2015,3.8
+30,Murcia,2016,3.8
+30,Murcia,2017,3.9
+30,Murcia,2018,4
+30,Murcia,2019,4.3
+30,Murcia,2020,4.4
+30,Murcia,2021,4.6
+30,Murcia,2022,4.8
+30,Murcia,2023,5.1
+31,Navarra,2021,5.9
+31,Navarra,2022,6.2
+31,Navarra,2023,6.6
+32,Ourense,2011,3.6
+32,Ourense,2012,3.6
+32,Ourense,2013,3.6
+32,Ourense,2014,3.6
+32,Ourense,2015,3.6
+32,Ourense,2016,3.7
+32,Ourense,2017,3.7
+32,Ourense,2018,3.8
+32,Ourense,2019,4
+32,Ourense,2020,4.1
+32,Ourense,2021,4.2
+32,Ourense,2022,4.3
+32,Ourense,2023,4.4
+33,Asturias,2011,5.4
+33,Asturias,2012,5.4
+33,Asturias,2013,5.3
+33,Asturias,2014,5.2
+33,Asturias,2015,5.2
+33,Asturias,2016,5.3
+33,Asturias,2017,5.3
+33,Asturias,2018,5.4
+33,Asturias,2019,5.7
+33,Asturias,2020,5.8
+33,Asturias,2021,6
+33,Asturias,2022,6.1
+33,Asturias,2023,6.4
+34,Palencia,2011,4.2
+34,Palencia,2012,4.3
+34,Palencia,2013,4.2
+34,Palencia,2014,4.2
+34,Palencia,2015,4.3
+34,Palencia,2016,4.3
+34,Palencia,2017,4.4
+34,Palencia,2018,4.5
+34,Palencia,2019,4.8
+34,Palencia,2020,4.9
+34,Palencia,2021,5
+34,Palencia,2022,5.1
+34,Palencia,2023,5.3
+35,Palmas, Las,2011,5.6
+35,Palmas, Las,2012,5.5
+35,Palmas, Las,2013,5.3
+35,Palmas, Las,2014,5.3
+35,Palmas, Las,2015,5.4
+35,Palmas, Las,2016,5.5
+35,Palmas, Las,2017,5.6
+35,Palmas, Las,2018,5.8
+35,Palmas, Las,2019,6.3
+35,Palmas, Las,2020,6.4
+35,Palmas, Las,2021,6.6
+35,Palmas, Las,2022,6.9
+35,Palmas, Las,2023,7.2
+36,Pontevedra,2011,4.9
+36,Pontevedra,2012,4.9
+36,Pontevedra,2013,4.8
+36,Pontevedra,2014,4.7
+36,Pontevedra,2015,4.7
+36,Pontevedra,2016,4.8
+36,Pontevedra,2017,4.9
+36,Pontevedra,2018,4.9
+36,Pontevedra,2019,5.3
+36,Pontevedra,2020,5.4
+36,Pontevedra,2021,5.6
+36,Pontevedra,2022,5.8
+36,Pontevedra,2023,6
+37,Salamanca,2011,4.7
+37,Salamanca,2012,4.6
+37,Salamanca,2013,4.5
+37,Salamanca,2014,4.5
+37,Salamanca,2015,4.5
+37,Salamanca,2016,4.6
+37,Salamanca,2017,4.6
+37,Salamanca,2018,4.7
+37,Salamanca,2019,5
+37,Salamanca,2020,5.1
+37,Salamanca,2021,5.2
+37,Salamanca,2022,5.4
+37,Salamanca,2023,5.6
+38,Santa Cruz de Tenerife,2011,5.6
+38,Santa Cruz de Tenerife,2012,5.4
+38,Santa Cruz de Tenerife,2013,5.3
+38,Santa Cruz de Tenerife,2014,5.3
+38,Santa Cruz de Tenerife,2015,5.3
+38,Santa Cruz de Tenerife,2016,5.4
+38,Santa Cruz de Tenerife,2017,5.6
+38,Santa Cruz de Tenerife,2018,5.8
+38,Santa Cruz de Tenerife,2019,6.3
+38,Santa Cruz de Tenerife,2020,6.5
+38,Santa Cruz de Tenerife,2021,6.7
+38,Santa Cruz de Tenerife,2022,7.1
+38,Santa Cruz de Tenerife,2023,7.5
+39,Cantabria,2011,5.9
+39,Cantabria,2012,5.8
+39,Cantabria,2013,5.6
+39,Cantabria,2014,5.5
+39,Cantabria,2015,5.4
+39,Cantabria,2016,5.5
+39,Cantabria,2017,5.6
+39,Cantabria,2018,5.7
+39,Cantabria,2019,6
+39,Cantabria,2020,6.1
+39,Cantabria,2021,6.3
+39,Cantabria,2022,6.5
+39,Cantabria,2023,6.9
+40,Segovia,2011,5.2
+40,Segovia,2012,5
+40,Segovia,2013,4.8
+40,Segovia,2014,4.7
+40,Segovia,2015,4.6
+40,Segovia,2016,4.7
+40,Segovia,2017,4.7
+40,Segovia,2018,4.8
+40,Segovia,2019,5.1
+40,Segovia,2020,5.2
+40,Segovia,2021,5.4
+40,Segovia,2022,5.6
+40,Segovia,2023,5.9
+41,Sevilla,2011,6.5
+41,Sevilla,2012,6.4
+41,Sevilla,2013,6
+41,Sevilla,2014,5.9
+41,Sevilla,2015,5.9
+41,Sevilla,2016,6
+41,Sevilla,2017,6.1
+41,Sevilla,2018,6.3
+41,Sevilla,2019,6.8
+41,Sevilla,2020,7
+41,Sevilla,2021,7.3
+41,Sevilla,2022,7.6
+41,Sevilla,2023,8
+42,Soria,2011,4.9
+42,Soria,2012,4.8
+42,Soria,2013,4.6
+42,Soria,2014,4.4
+42,Soria,2015,4.4
+42,Soria,2016,4.5
+42,Soria,2017,4.5
+42,Soria,2018,4.7
+42,Soria,2019,5.1
+42,Soria,2020,5.2
+42,Soria,2021,5.3
+42,Soria,2022,5.5
+42,Soria,2023,5.8
+43,Tarragona,2011,5.5
+43,Tarragona,2012,5.2
+43,Tarragona,2013,5
+43,Tarragona,2014,4.9
+43,Tarragona,2015,4.8
+43,Tarragona,2016,4.9
+43,Tarragona,2017,5
+43,Tarragona,2018,5.2
+43,Tarragona,2019,5.6
+43,Tarragona,2020,5.7
+43,Tarragona,2021,5.9
+43,Tarragona,2022,6.2
+43,Tarragona,2023,6.5
+44,Teruel,2011,4
+44,Teruel,2012,3.8
+44,Teruel,2013,3.7
+44,Teruel,2014,3.6
+44,Teruel,2015,3.6
+44,Teruel,2016,3.6
+44,Teruel,2017,3.6
+44,Teruel,2018,3.7
+44,Teruel,2019,4
+44,Teruel,2020,4.1
+44,Teruel,2021,4.3
+44,Teruel,2022,4.4
+44,Teruel,2023,4.6
+45,Toledo,2011,4.9
+45,Toledo,2012,4.6
+45,Toledo,2013,4.3
+45,Toledo,2014,4.1
+45,Toledo,2015,4
+45,Toledo,2016,4.1
+45,Toledo,2017,4.2
+45,Toledo,2018,4.3
+45,Toledo,2019,4.7
+45,Toledo,2020,4.9
+45,Toledo,2021,5.1
+45,Toledo,2022,5.4
+45,Toledo,2023,5.7
+46,Valencia/Valéncia,2011,4.6
+46,Valencia/Valéncia,2012,4.4
+46,Valencia/Valéncia,2013,4.2
+46,Valencia/Valéncia,2014,4.1
+46,Valencia/Valéncia,2015,4.1
+46,Valencia/Valéncia,2016,4.2
+46,Valencia/Valéncia,2017,4.3
+46,Valencia/Valéncia,2018,4.5
+46,Valencia/Valéncia,2019,4.9
+46,Valencia/Valéncia,2020,5.2
+46,Valencia/Valéncia,2021,5.4
+46,Valencia/Valéncia,2022,5.8
+46,Valencia/Valéncia,2023,6.2
+47,Valladolid,2011,5.2
+47,Valladolid,2012,5.1
+47,Valladolid,2013,4.9
+47,Valladolid,2014,4.8
+47,Valladolid,2015,4.8
+47,Valladolid,2016,4.9
+47,Valladolid,2017,5
+47,Valladolid,2018,5.1
+47,Valladolid,2019,5.5
+47,Valladolid,2020,5.6
+47,Valladolid,2021,5.8
+47,Valladolid,2022,6
+47,Valladolid,2023,6.2
+49,Zamora,2011,3.7
+49,Zamora,2012,3.7
+49,Zamora,2013,3.7
+49,Zamora,2014,3.6
+49,Zamora,2015,3.6
+49,Zamora,2016,3.7
+49,Zamora,2017,3.7
+49,Zamora,2018,3.8
+49,Zamora,2019,4
+49,Zamora,2020,4.1
+49,Zamora,2021,4.2
+49,Zamora,2022,4.3
+49,Zamora,2023,4.4
+50,Zaragoza,2011,6.2
+50,Zaragoza,2012,6
+50,Zaragoza,2013,5.6
+50,Zaragoza,2014,5.5
+50,Zaragoza,2015,5.5
+50,Zaragoza,2016,5.5
+50,Zaragoza,2017,5.6
+50,Zaragoza,2018,5.8
+50,Zaragoza,2019,6.2
+50,Zaragoza,2020,6.3
+50,Zaragoza,2021,6.5
+50,Zaragoza,2022,6.8
+50,Zaragoza,2023,7.1
+51,Ceuta,2011,7.7
+51,Ceuta,2012,7.8
+51,Ceuta,2013,7.6
+51,Ceuta,2014,7.6
+51,Ceuta,2015,7.6
+51,Ceuta,2016,7.8
+51,Ceuta,2017,7.7
+51,Ceuta,2018,8
+51,Ceuta,2019,8.3
+51,Ceuta,2020,8.5
+51,Ceuta,2021,8.8
+51,Ceuta,2022,8.8
+51,Ceuta,2023,9.2
+52,Melilla,2011,6.8
+52,Melilla,2012,6.9
+52,Melilla,2013,7
+52,Melilla,2014,6.9
+52,Melilla,2015,7
+52,Melilla,2016,7
+52,Melilla,2017,7.4
+52,Melilla,2018,7.6
+52,Melilla,2019,7.9
+52,Melilla,2020,8.1
+52,Melilla,2021,8.3
+52,Melilla,2022,8.6
+52,Melilla,2023,8.8

--- a/alquiler-dashboard/scripts/mitma_pivot.mjs
+++ b/alquiler-dashboard/scripts/mitma_pivot.mjs
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import { parse } from 'csv-parse/sync';
+
+const raw = fs.readFileSync('src/data/precio_alquileres_provincia.csv', 'utf8');
+const rows = parse(raw, { columns: true, delimiter: ';' });
+
+const toNum = s => (s ? +s.replace(',', '.') : null);
+
+const out = [];
+rows.forEach(r => {
+  const cproKey = Object.keys(r).find(k => k.replace(/^\uFEFF/, '') === 'CPRO');
+  const litKey = Object.keys(r).find(k => k.includes('LITPRO'));
+  const cod = String(r[cproKey]).padStart(2, '0');
+  const prov = (r[litKey] || '').trim();
+  for (let y = 11; y <= 23; y++) {
+    const col = `ALQM2_LV_M_VC_${y}`;
+    if (r[col]) {
+      const num = toNum(r[col]);
+      if (!Number.isNaN(num)) {
+        out.push({
+          cod_provincia: cod,
+          provincia: prov,
+          anio: 2000 + y,
+          euros_m2: num,
+        });
+      }
+    }
+  }
+});
+
+const csvContent =
+  'cod_provincia,provincia,anio,euros_m2\n' +
+  out.map(o => `${o.cod_provincia},${o.provincia},${o.anio},${o.euros_m2}`).join('\n');
+fs.writeFileSync('public/alquiler_euros_prov_2011_2023.csv', csvContent);
+console.log('\u2714 CSV listo: public/alquiler_euros_prov_2011_2023.csv');
+

--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -5,16 +5,15 @@ import Map from './components/Map';
 import Legend from './components/Legend';
 import Treemap from './components/Treemap';
 import './styles/dashboard.css';
-import useIndiceData from './hooks/useIndiceData';
+import useAlquilerEuros from './hooks/useAlquilerEuros';
 import createColorScale from './utils/colorScale.js';
 
 function App() {
-  const { records, years, sizeOptions, getFiltered } = useIndiceData();
+  const { records, years, getFiltered } = useAlquilerEuros();
   const minYear = years[0];
   const maxYear = years[years.length - 1];
   const [from, setFrom] = useState(minYear);
   const [to, setTo] = useState(maxYear);
-  const [size, setSize] = useState('Total');
 
   const STEP = 1;
   const MIN = minYear;
@@ -72,10 +71,10 @@ function App() {
   const [selectedCca, setSelectedCca] = useState(null);
 
   const filtered = useMemo(
-    () => getFiltered({ from, to, size }),
-    [getFiltered, from, to, size]
+    () => getFiltered({ from, to }),
+    [getFiltered, from, to]
   );
-  const vals = filtered.map(d => d.valor);
+  const vals = filtered.map(d => d.euros_m2);
   const colorDomain = vals.length ? [Math.min(...vals), Math.max(...vals)] : [0, 1];
   const colorScale = useMemo(
     () => (colorDomain ? createColorScale(colorDomain) : null),
@@ -89,13 +88,6 @@ function App() {
     <div>
       <h1>Dashboard de alquileres</h1>
       <div className="controls">
-        <label>Tamaño:</label>
-        <select value={size} onChange={e => setSize(e.target.value)}>
-          <option value="Total">Total</option>
-          {sizeOptions.map(o => (
-            <option key={o}>{o}</option>
-          ))}
-        </select>
         <label>Años:</label>
         <YearRange
           values={[from, to]}

--- a/alquiler-dashboard/src/components/Legend.jsx
+++ b/alquiler-dashboard/src/components/Legend.jsx
@@ -8,10 +8,11 @@ export default function Legend({ scale }) {
       <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
         <svg
           width={width}
-          height={24}
+          height={30}
           aria-label="leyenda"
           role="img"
         >
+        <text x={width / 2} y={10} fontSize={10} textAnchor="middle">€/m²</text>
         {rects.map((c, i) => {
           const [t0] = scale.invertExtent(c);
           return (

--- a/alquiler-dashboard/src/components/Map.jsx
+++ b/alquiler-dashboard/src/components/Map.jsx
@@ -49,19 +49,14 @@ export default function Map({ filtered, colorScaleDomain, onSelect, selectedCca 
   const showTooltip = (id, info, event) => {
     if (!tooltipRef.current) return;
     const name = provinceNames[id] || `Provincia ${id}`;
-    const indice = info?.indice;
-    const euros = info?.euros;
+    const euros = info;
     tooltipRef.current
       .html(
-        `<strong>${name}</strong><br/>Índice: ${
-          indice != null && !Number.isNaN(indice)
-            ? indice.toFixed(1).replace('.', ',')
-            : 'Sin dato'
-        }<br/>€: ${
+        `<strong>${name}</strong><br/>Alquiler medio: ${
           euros != null && !Number.isNaN(euros)
-            ? euros.toFixed(0).replace('.', ',')
+            ? euros.toFixed(2).replace('.', ',')
             : 'Sin dato'
-        }`
+        } €/m²`
       )
       .style('left', `${event.pageX + 10}px`)
       .style('top', `${event.pageY + 10}px`)
@@ -90,11 +85,8 @@ export default function Map({ filtered, colorScaleDomain, onSelect, selectedCca 
     projection.fitSize([width, height], { type: 'FeatureCollection', features });
 
     const values = d3.rollup(
-      filtered.filter(d => d.valor != null && !Number.isNaN(d.valor)),
-      v => ({
-        indice: d3.mean(v, d => d.valor),
-        euros: d3.mean(v, d => d.euros),
-      }),
+      filtered.filter(d => d.euros_m2 != null && !Number.isNaN(d.euros_m2)),
+      v => d3.mean(v, d => d.euros_m2),
       d => d.cod_provincia
     );
 
@@ -129,8 +121,8 @@ export default function Map({ filtered, colorScaleDomain, onSelect, selectedCca 
       .transition()
       .duration(600)
       .attr('fill', d => {
-        const val = values.get(d.id);
-        return val != null ? color(val.indice) : '#ccc';
+        const v = values.get(d.id);
+        return v != null ? color(v) : '#ccc';
       });
   }, [features, filtered, colorScale, onSelect, selectedCca]);
 

--- a/alquiler-dashboard/src/components/Treemap.jsx
+++ b/alquiler-dashboard/src/components/Treemap.jsx
@@ -15,8 +15,7 @@ function Treemap({ filtered, onSelect, selectedCca, colorDomain }) {
       .rollups(
         filtered,
         v => ({
-          valor: d3.mean(v, d => d.valor),
-          euros: d3.mean(v, d => d.euros),
+          euros_m2: d3.mean(v, d => d.euros_m2),
           poblacion: v.length,
         }),
         d => provToCca[d.cod_provincia]
@@ -34,7 +33,7 @@ function Treemap({ filtered, onSelect, selectedCca, colorDomain }) {
       .attr('y', d => d.y0)
       .attr('width', d => d.x1 - d.x0)
       .attr('height', d => d.y1 - d.y0)
-      .attr('fill', d => scale(d.data.valor))
+      .attr('fill', d => scale(d.data.euros_m2))
       .attr('stroke', '#222')
       .style('opacity', d => (selectedCca && d.data.cca !== selectedCca ? 0.3 : 1))
       .on('click', (e, d) => onSelect && onSelect(d.data.cca))
@@ -42,10 +41,10 @@ function Treemap({ filtered, onSelect, selectedCca, colorDomain }) {
       .data(d => [d])
       .join('title')
       .text(d => {
-        const v = d.data.valor;
+        const v = d.data.euros_m2;
         return `${ccaNames[d.data.cca]}: ${
-          v != null ? v.toFixed(1).replace('.', ',') : 'Sin dato'
-        }`;
+          v != null ? v.toFixed(2).replace('.', ',') : 'Sin dato'
+        } €/m²`;
       });
   }, [filtered, selectedCca, colorDomain, onSelect]);
 

--- a/alquiler-dashboard/src/hooks/useAlquilerEuros.js
+++ b/alquiler-dashboard/src/hooks/useAlquilerEuros.js
@@ -1,0 +1,39 @@
+import { useEffect, useState, useMemo, useCallback } from 'react';
+import * as d3 from 'd3';
+import csvRaw from '../../public/alquiler_euros_prov_2011_2023.csv?raw';
+
+export default function useAlquilerEuros() {
+  const [records, setRecords] = useState([]);
+
+  useEffect(() => {
+    const parse = d3.dsvFormat(',').parse;
+    const data = parse(csvRaw, r => ({
+      cod_provincia: r.cod_provincia,
+      provincia: r.provincia,
+      anio: +r.anio,
+      euros_m2: +r.euros_m2,
+    }));
+    setRecords(data);
+  }, []);
+
+  const years = useMemo(() => {
+    if (!records.length) return [];
+    const min = d3.min(records, d => d.anio);
+    const max = d3.max(records, d => d.anio);
+    const out = [];
+    for (let y = min; y <= max; y++) out.push(y);
+    return out;
+  }, [records]);
+
+  const getFiltered = useCallback(
+    ({ from, to }) => records.filter(d => d.anio >= from && d.anio <= to),
+    [records]
+  );
+
+  const domain = useCallback(filtered => {
+    const vals = filtered.map(d => d.euros_m2).filter(v => !Number.isNaN(v));
+    return d3.extent(vals);
+  }, []);
+
+  return { records, years, getFiltered, domain };
+}


### PR DESCRIPTION
## Summary
- transform MITMA dataset to long-form euros per m²
- add hook to load the new CSV
- color map and treemap using €/m²
- update legend label and UI controls
- run transformation on postinstall

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a3a27a3c483299cbd75806629753d