### PR TITLE
UX POLISH – año↔filter, leyenda pro y etiquetas treemap

### DIFF
--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -32,3 +32,4 @@ La interfaz usa un *dashboard* oscuro con tarjetas y cuadrícula CSS Grid.
 ![Captura del nuevo diseño](TODO)
 
 Nuevo selector de años con doble asa, mapa anclado a la derecha.
+Leyenda muestra €/m² y treemap etiqueta CCAA.

--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -104,8 +104,8 @@ function App() {
             <YearRange
               values={[from, to]}
               onChange={([f, t]) => {
-                setFrom(Math.min(f, t));
-                setTo(Math.max(f, t));
+                setFrom(f);
+                setTo(t);
               }}
             />
           )}

--- a/alquiler-dashboard/src/components/Legend.jsx
+++ b/alquiler-dashboard/src/components/Legend.jsx
@@ -1,39 +1,54 @@
 export default function Legend({ scale }) {
-
   if (scale && typeof scale.invertExtent === 'function') {
     const rects = scale.range();
-    const last = scale.invertExtent(rects[rects.length - 1])[1];
-    const width = rects.length * 25;
+    const max = scale.invertExtent(rects[rects.length - 1])[1];
+
+    const width = 220;
+    const pad = 6;
+    const step = 30;
+
     return (
-      <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
-        <svg
-          width={width}
-          height={30}
-          aria-label="leyenda"
-          role="img"
-        >
-        <text x={width / 2} y={10} fontSize={10} textAnchor="middle">€/m²</text>
-        {rects.map((c, i) => {
-          const [t0] = scale.invertExtent(c);
-          return (
-            <g key={i}>
-              <rect x={i * 25} width={24} height={12} fill={c} />
-              <text x={i * 25} y={22} fontSize={10} textAnchor="start">
-                {t0.toFixed ? t0.toFixed(0) : t0}
-              </text>
-            </g>
-          );
-        })}
-        <text
-          x={rects.length * 25}
-          y={22}
-          fontSize={10}
-          textAnchor="end"
-        >
-          {last.toFixed ? last.toFixed(0) : last}
-        </text>
-        </svg>
-      </div>
+      <svg
+        width={width}
+        height={40}
+        aria-label="leyenda"
+        role="img"
+        style={{ border: '1px solid #444', background: '#1e1e1e' }}
+      >
+        <g transform={`translate(${pad},${pad})`}>
+          <text
+            x={(width - pad * 2) / 2}
+            y={0}
+            dy="0.8em"
+            fontSize={10}
+            textAnchor="middle"
+            fill="#fff"
+          >
+            €/m²
+          </text>
+          {rects.map((c, i) => {
+            const [t0] = scale.invertExtent(c);
+            const x = i * step;
+            return (
+              <g key={i}>
+                <rect x={x} y={8} width={24} height={12} fill={c} />
+                <text x={x} y={24} fontSize={10} fill="#fff">
+                  {t0.toFixed ? t0.toFixed(1) : t0}
+                </text>
+              </g>
+            );
+          })}
+          <text
+            x={(rects.length - 1) * step + 24}
+            y={24}
+            fontSize={10}
+            textAnchor="end"
+            fill="#fff"
+          >
+            {max.toFixed ? max.toFixed(1) : max}
+          </text>
+        </g>
+      </svg>
     );
   }
 

--- a/alquiler-dashboard/src/components/Treemap.jsx
+++ b/alquiler-dashboard/src/components/Treemap.jsx
@@ -25,11 +25,23 @@ function Treemap({ filtered, onSelect, selectedCca, colorDomain }) {
     treemap().size([300, 300]).padding(1)(root);
 
     const svg = d3.select(ref.current);
-    const sel = svg.selectAll('rect.tile').data(root.leaves(), d => d.data.cca);
+    const sel = svg.selectAll('g.tile').data(root.leaves(), d => d.data.cca);
 
-    sel
-      .join('rect')
+    const g = sel
+      .join('g')
       .classed('tile', true)
+      .style('cursor', 'pointer')
+      .on('click', (e, d) => {
+        if (!onSelect) return;
+        if (selectedCca === d.data.cca) onSelect(null);
+        else onSelect(d.data.cca);
+        e.stopPropagation();
+      });
+
+    g
+      .selectAll('rect')
+      .data(d => [d])
+      .join('rect')
       .attr('x', d => d.x0)
       .attr('y', d => d.y0)
       .attr('width', d => d.x1 - d.x0)
@@ -38,13 +50,22 @@ function Treemap({ filtered, onSelect, selectedCca, colorDomain }) {
       .attr('stroke', '#222')
       .style('opacity', d =>
         selectedCca && d.data.cca !== selectedCca ? 0.3 : 1
-      )
-      .on('click', (e, d) => {
-        if (!onSelect) return;
-        if (selectedCca === d.data.cca) onSelect(null);
-        else onSelect(d.data.cca);
-        e.stopPropagation();
-      })
+      );
+
+    g
+      .selectAll('text')
+      .data(d => [d])
+      .join('text')
+      .text(d => d.data.cca)
+      .attr('x', d => (d.x0 + d.x1) / 2)
+      .attr('y', d => (d.y0 + d.y1) / 2)
+      .attr('fill', '#fff')
+      .attr('font-size', '10px')
+      .attr('pointer-events', 'none')
+      .attr('text-anchor', 'middle')
+      .style('display', d => (d.x1 - d.x0) < 40 ? 'none' : null);
+
+    g
       .selectAll('title')
       .data(d => [d])
       .join('title')


### PR DESCRIPTION
## Summary
- ensure `YearRange` updates from/to without reordering
- improve legend visuals and numbers with max label
- label each treemap rectangle with its CCAA code
- document legend and treemap enhancements

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a410680188329a80a80de56a42989