### PR TITLE
Fix slider for year range filtering

### DIFF
--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -12,12 +12,10 @@ import createColorScale from './utils/colorScale.js';
 import provToCca from './utils/provToCca.js';
 
 function App() {
-  const { records, years, getFiltered } = useAlquilerEuros();
+  const { records, years, getByYear } = useAlquilerEuros();
   const minYear = years[0];
   const maxYear = years[years.length - 1];
-  const [from, setFrom] = useState();
-  const [to, setTo] = useState();
-  const [yearsReady, setYearsReady] = useState(false);
+  const [range, setRange] = useState([]);
 
   const STEP = 1;
   const MIN = minYear;
@@ -45,32 +43,25 @@ function App() {
           </div>
         )}
         allowOverlap={false}
-        renderThumb={({ key, props, index }) => (
-          <div
-            key={key}
-            {...props}
-            style={{ ...props.style, outline: 'none' }}
-            aria-label={index === 0 ? 'Desde' : 'Hasta'}
-          />
+        renderThumb={({ key, props }) => (
+          <div key={key} {...props} style={{ ...props.style, outline: 'none' }} />
         )}
       />
     );
   }
 
   useEffect(() => {
-    if (years.length && !yearsReady) {
-      setFrom(years[0]);
-      setTo(years.at(-1));
-      setYearsReady(true);
+    if (years.length && !range.length) {
+      setRange([years[0], years.at(-1)]);
     }
-  }, [years, yearsReady]);
+  }, [years]);
 
   const [provinciaSel, setProvinciaSel] = useState(null);
   const [selectedCca, setSelectedCca] = useState(null);
 
   const filtered = useMemo(
-    () => getFiltered({ from, to }),
-    [getFiltered, from, to]
+    () => getByYear(range[0], range[1]),
+    [getByYear, range]
   );
   const vals = filtered.map(d => d.euros_m2);
   const colorDomain = vals.length ? [Math.min(...vals), Math.max(...vals)] : [0, 1];
@@ -100,16 +91,13 @@ function App() {
       <h1>Dashboard de alquileres</h1>
       <div className="controls">
         <label>Años:</label>
-          {yearsReady && (
+          {range.length && (
             <YearRange
-              values={[from, to]}
-              onChange={([f, t]) => {
-                setFrom(f);
-                setTo(t);
-              }}
+              values={range}
+              onChange={v => setRange([Math.min(...v), Math.max(...v)])}
             />
           )}
-        {yearsReady && <span>{from} – {to}</span>}
+        {range.length && <span>{range[0]} – {range[1]}</span>}
       </div>
 
       <div className="grid-dash">

--- a/alquiler-dashboard/src/hooks/useAlquilerEuros.js
+++ b/alquiler-dashboard/src/hooks/useAlquilerEuros.js
@@ -30,10 +30,15 @@ export default function useAlquilerEuros() {
     [records]
   );
 
+  const getByYear = useCallback(
+    (from, to) => records.filter(r => r.anio >= from && r.anio <= to),
+    [records]
+  );
+
   const domain = useCallback(filtered => {
     const vals = filtered.map(d => d.euros_m2).filter(v => !Number.isNaN(v));
     return d3.extent(vals);
   }, []);
 
-  return { records, years, getFiltered, domain };
+  return { records, years, getFiltered, getByYear, domain };
 }


### PR DESCRIPTION
## Summary
- add `getByYear` helper to filter by year range
- track year range in `App.jsx` and initialize once data is ready
- update `YearRange` slider and show current range

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a42a1fcd08329b4aac605e29ce64c