### PR TITLE
Add histogram and scatter charts

### DIFF
--- a/alquiler-dashboard/src/components/Histogram.jsx
+++ b/alquiler-dashboard/src/components/Histogram.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+
+function Histogram({ data }) {
+  const ref = useRef();
+
+  useEffect(() => {
+    const width = 320;
+    const height = 160;
+    const svg = d3
+      .select(ref.current)
+      .attr('width', width)
+      .attr('height', height);
+
+    const x = d3
+      .scaleLinear()
+      .domain(d3.extent(data))
+      .nice()
+      .range([30, width - 10]);
+
+    const bins = d3.bin().domain(x.domain()).thresholds(10)(data);
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(bins, d => d.length)])
+      .range([height - 20, 10]);
+
+    svg.selectAll('*').remove();
+
+    svg
+      .append('g')
+      .selectAll('rect')
+      .data(bins)
+      .join('rect')
+      .attr('x', d => x(d.x0) + 1)
+      .attr('y', d => y(d.length))
+      .attr('width', d => x(d.x1) - x(d.x0) - 1)
+      .attr('height', d => y(0) - y(d.length))
+      .attr('fill', '#4f83cc');
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${height - 20})`)
+      .call(d3.axisBottom(x).ticks(5));
+  }, [data]);
+
+  return <svg ref={ref} role="img" aria-label="Histograma €/m²" />;
+}
+
+export default Histogram;

--- a/alquiler-dashboard/src/components/Scatter.jsx
+++ b/alquiler-dashboard/src/components/Scatter.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+
+function Scatter({ points }) {
+  const ref = useRef();
+
+  useEffect(() => {
+    const w = 320;
+    const h = 200;
+    const p = 30;
+
+    const x = d3
+      .scaleLinear()
+      .domain(d3.extent(points, d => d.indice))
+      .nice()
+      .range([p, w - p]);
+
+    const y = d3
+      .scaleLinear()
+      .domain(d3.extent(points, d => d.euros))
+      .nice()
+      .range([h - p, p]);
+
+    const svg = d3.select(ref.current).attr('width', w).attr('height', h);
+    svg.selectAll('*').remove();
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${h - p})`)
+      .call(d3.axisBottom(x));
+
+    svg
+      .append('g')
+      .attr('transform', `translate(${p},0)`)
+      .call(d3.axisLeft(y));
+
+    svg
+      .selectAll('circle')
+      .data(points)
+      .join('circle')
+      .attr('cx', d => x(d.indice))
+      .attr('cy', d => y(d.euros))
+      .attr('r', 4)
+      .attr('fill', '#90caf9')
+      .append('title')
+      .text(d => `${d.prov}: ${d.euros.toFixed(2)} €/m²`);
+  }, [points]);
+
+  return <svg ref={ref} role="img" aria-label="Scatter €/m² vs índice" />;
+}
+
+export default Scatter;

--- a/alquiler-dashboard/src/styles/dashboard.css
+++ b/alquiler-dashboard/src/styles/dashboard.css
@@ -38,14 +38,15 @@ h1 { font-size: clamp(1.8rem, 3vw, 2.8rem); margin: .5rem 0 1rem; }
     display: grid;
     grid-template-columns: 340px 1fr;
     grid-template-areas:
-      "legend  map"
-      "treemap map"
-      "parallel map";
+      "legend   map"
+      "treemap  map"
+      "histo    map"
+      "scatter  map";
     gap: 1rem;
   }
   .card.legend { grid-area: legend; }
   .card.treemap { grid-area: treemap; }
-  .card.parallel { grid-area: parallel; }
-  .card.line { grid-area: parallel; } /* ocupa el hueco vacío */
+  .card.histo { grid-area: histo; }
+  .card.scatter { grid-area: scatter; }
   .card.map { grid-area: map; }
 }


### PR DESCRIPTION
## Summary
- add new Histogram and Scatter components using d3
- show these charts in the dashboard
- load extra indice data for scatter plot
- update responsive layout

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a436a8d6483298ee99890712cbd86