### PR TITLE
Fix range slider and histogram edge cases

### DIFF
--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -18,7 +18,8 @@ function App() {
   const { records: indiceRecords } = useIndiceData();
   const minYear = years[0];
   const maxYear = years[years.length - 1];
-  const [range, setRange] = useState([]);
+  const [from, setFrom] = useState(null);
+  const [to, setTo] = useState(null);
 
   const STEP = 1;
   const MIN = minYear;
@@ -59,17 +60,18 @@ function App() {
   }
 
   useEffect(() => {
-    if (years.length && !range.length) {
-      setRange([years[0], years.at(-1)]);
+    if (years.length && from == null && to == null) {
+      setFrom(years[0]);
+      setTo(years.at(-1));
     }
-  }, [years]);
+  }, [years, from, to]);
 
   const [provinciaSel, setProvinciaSel] = useState(null);
   const [selectedCca, setSelectedCca] = useState(null);
 
   const filtered = useMemo(
-    () => getByYear(range[0], range[1]),
-    [getByYear, range]
+    () => (from != null && to != null ? getByYear(from, to) : []),
+    [getByYear, from, to]
   );
 
   const baseData = useMemo(
@@ -87,7 +89,8 @@ function App() {
   );
 
   const histoData = baseData.map(d => d.euros_m2);
-  const yearMid = range.length ? Math.round((range[0] + range[1]) / 2) : null;
+  const yearMid =
+    from != null && to != null ? Math.round((from + to) / 2) : null;
   const scatterPts = useMemo(() => {
     if (!indiceRecords.length || yearMid == null) return [];
     return indiceRecords
@@ -113,10 +116,14 @@ function App() {
       <h1>Dashboard de alquileres</h1>
       <div className="controls">
         <label>Años:</label>
-          {range.length && (
+          {from != null && to != null && (
             <YearRange
-              values={range}
-              onChange={v => setRange([Math.min(...v), Math.max(...v)])}
+              values={[from, to]}
+              onChange={v => {
+                const [a, b] = v;
+                setFrom(a);
+                setTo(b);
+              }}
             />
           )}
       </div>

--- a/alquiler-dashboard/src/components/Histogram.jsx
+++ b/alquiler-dashboard/src/components/Histogram.jsx
@@ -5,8 +5,15 @@ function Histogram({ data }) {
   const ref = useRef();
 
   useEffect(() => {
-    if (!data.length) {
+    if (data.length === 0) {
       d3.select(ref.current).selectAll('*').remove();
+      d3.select(ref.current)
+        .append('text')
+        .attr('x', 160)
+        .attr('y', 80)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#777')
+        .text('Sin datos');
       return;
     }
     const width = 320;
@@ -47,15 +54,7 @@ function Histogram({ data }) {
       .call(d3.axisBottom(x).ticks(5));
   }, [data]);
 
-  return (
-    <svg ref={ref} role="img" aria-label="Histograma €/m²">
-      {data.length === 0 && (
-        <text x="50%" y="50%" textAnchor="middle" fill="#777">
-          Sin datos
-        </text>
-      )}
-    </svg>
-  );
+  return <svg ref={ref} role="img" aria-label="Histograma €/m²" />;
 }
 
 export default Histogram;


### PR DESCRIPTION
## Summary
- show slider thumbs with unique keys
- manage year range safely with `from`/`to` state vars
- avoid RangeError by guarding `YearRange`
- remove DOM manipulation warning by handling empty histogram with d3

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a49b9fdac8329a4ca757366547a53