### PR TITLE
Fix React key warning and D3 cleanup

### DIFF
--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -50,9 +50,16 @@ function App() {
             </div>
           )}
           allowOverlap={false}
-          renderThumb={({ key, props }) => (
-            <div key={key} {...props} style={{ ...props.style, ...THUMB }} />
-          )}
+          renderThumb={({ props, index }) => {
+            const { key: thumbKey, ...rest } = props;
+            return (
+              <div
+                key={thumbKey ?? index}
+                {...rest}
+                style={{ ...rest.style, ...THUMB }}
+              />
+            );
+          }}
         />
         <div style={{ textAlign: 'center', marginTop: 4 }}>{from} – {to}</div>
       </div>
@@ -119,8 +126,7 @@ function App() {
           {from != null && to != null && (
             <YearRange
               values={[from, to]}
-              onChange={v => {
-                const [a, b] = v;
+              onChange={([a, b]) => {
                 setFrom(a);
                 setTo(b);
               }}

--- a/alquiler-dashboard/src/components/Histogram.jsx
+++ b/alquiler-dashboard/src/components/Histogram.jsx
@@ -5,23 +5,25 @@ function Histogram({ data }) {
   const ref = useRef();
 
   useEffect(() => {
-    if (data.length === 0) {
-      d3.select(ref.current).selectAll('*').remove();
-      d3.select(ref.current)
-        .append('text')
-        .attr('x', 160)
-        .attr('y', 80)
-        .attr('text-anchor', 'middle')
-        .attr('fill', '#777')
-        .text('Sin datos');
-      return;
-    }
     const width = 320;
     const height = 160;
     const svg = d3
       .select(ref.current)
       .attr('width', width)
       .attr('height', height);
+
+    svg.selectAll('*').remove();
+
+    if (data.length === 0) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#777')
+        .text('Sin datos');
+      return () => svg.selectAll('*').remove();
+    }
 
     const x = d3
       .scaleLinear()
@@ -34,8 +36,6 @@ function Histogram({ data }) {
       .scaleLinear()
       .domain([0, d3.max(bins, d => d.length)])
       .range([height - 20, 10]);
-
-    svg.selectAll('*').remove();
 
     svg
       .append('g')
@@ -52,6 +52,8 @@ function Histogram({ data }) {
       .append('g')
       .attr('transform', `translate(0,${height - 20})`)
       .call(d3.axisBottom(x).ticks(5));
+
+    return () => svg.selectAll('*').remove();
   }, [data]);
 
   return <svg ref={ref} role="img" aria-label="Histograma €/m²" />;

--- a/alquiler-dashboard/src/components/Scatter.jsx
+++ b/alquiler-dashboard/src/components/Scatter.jsx
@@ -5,13 +5,24 @@ function Scatter({ points, selectedCca }) {
   const ref = useRef();
 
   useEffect(() => {
-    if (!points.length) {
-      d3.select(ref.current).selectAll('*').remove();
-      return;
-    }
     const w = 320;
     const h = 200;
     const p = 30;
+
+    const svg = d3.select(ref.current).attr('width', w).attr('height', h);
+
+    svg.selectAll('*').remove();
+
+    if (!points.length) {
+      svg
+        .append('text')
+        .attr('x', w / 2)
+        .attr('y', h / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#777')
+        .text('Sin datos');
+      return () => svg.selectAll('*').remove();
+    }
 
     const x = d3
       .scaleLinear()
@@ -25,8 +36,6 @@ function Scatter({ points, selectedCca }) {
       .nice()
       .range([h - p, p]);
 
-    const svg = d3.select(ref.current).attr('width', w).attr('height', h);
-    svg.selectAll('*').remove();
 
     svg
       .append('g')
@@ -50,17 +59,11 @@ function Scatter({ points, selectedCca }) {
       .attr('fill', fill)
       .append('title')
       .text(d => `${d.prov}: ${d.euros.toFixed(2)} €/m²`);
+
+    return () => svg.selectAll('*').remove();
   }, [points, selectedCca]);
 
-  return (
-    <svg ref={ref} role="img" aria-label="Scatter €/m² vs índice">
-      {points.length === 0 && (
-        <text x="50%" y="50%" textAnchor="middle" fill="#777">
-          Sin datos
-        </text>
-      )}
-    </svg>
-  );
+  return <svg ref={ref} role="img" aria-label="Scatter €/m² vs índice" />;
 }
 
 export default Scatter;


### PR DESCRIPTION
## Summary
- remove `key` from props spread when rendering slider thumbs
- ensure Histogram and Scatter clean up D3-generated nodes
- reorder YearRange values in handler

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a4bf7354c83298dd21cbf5cb55487