### PR TITLE
Rediseño dashboard con mapa centrado

### DIFF
--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -4,7 +4,7 @@ import { Range } from 'react-range';
 import Map from './components/Map';
 import Legend from './components/Legend';
 import Treemap from './components/Treemap';
-import Histogram from './components/Histogram';
+import DensityLine from './components/DensityLine';
 import Scatter from './components/Scatter';
 import './styles/dashboard.css';
 import useAlquilerEuros from './hooks/useAlquilerEuros';
@@ -95,7 +95,7 @@ function App() {
     [colorDomain]
   );
 
-  const histoData = baseData.map(d => d.euros_m2);
+  const lineData = baseData.map(d => d.euros_m2);
   const yearMid =
     from != null && to != null ? Math.round((from + to) / 2) : null;
   const scatterPts = useMemo(() => {
@@ -132,22 +132,13 @@ function App() {
               }}
             />
           )}
+        <button onClick={() => setSelectedCca(null)} disabled={!selectedCca} style={{marginLeft:'1rem'}}>
+          Reset CCAA
+        </button>
       </div>
 
       <div className="grid-dash">
-        <div className="card legend" role="region" aria-label="Leyenda de colores" key="legend">
-          <Legend scale={colorScale} />
-        </div>
-        <button onClick={() => setSelectedCca(null)} disabled={!selectedCca}>
-          Reset CCAA
-        </button>
-        <div
-          className="card treemap"
-          role="region"
-          aria-label="Treemap por comunidad"
-          key="treemap"
-          onClick={() => setSelectedCca(null)}
-        >
+        <div className="card treemap" role="region" aria-label="Treemap por comunidad" key="treemap" onClick={() => setSelectedCca(null)}>
           <Treemap
             filtered={filtered}
             selectedCca={selectedCca}
@@ -155,24 +146,22 @@ function App() {
             colorDomain={colorDomain}
           />
         </div>
-        <div className="card histo" key="histo">
-          <Histogram data={histoData} />
-        </div>
-        <div className="card scatter" key="scatter">
-          <Scatter points={scatterPts} selectedCca={selectedCca} />
-        </div>
-        <div
-          className="card map"
-          role="region"
-          aria-label="Mapa de alquileres por provincia"
-          key="map"
-        >
+        <div className="card map" role="region" aria-label="Mapa de alquileres por provincia" key="map">
           <Map
             filtered={filtered}
             colorScaleDomain={colorDomain}
             onSelect={setProvinciaSel}
             selectedCca={selectedCca}
           />
+        </div>
+        <div className="card scatter" key="scatter">
+          <Scatter points={scatterPts} selectedCca={selectedCca} />
+        </div>
+        <div className="card line" key="line">
+          <DensityLine data={lineData} />
+        </div>
+        <div className="card legend" role="region" aria-label="Leyenda de colores" key="legend">
+          <Legend scale={colorScale} />
         </div>
       </div>
       {provinciaSel && (

--- a/alquiler-dashboard/src/components/DensityLine.jsx
+++ b/alquiler-dashboard/src/components/DensityLine.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+
+export default function DensityLine({ data }) {
+  const ref = useRef();
+
+  useEffect(() => {
+    const w = 320;
+    const h = 160;
+    const m = 30;
+    const svg = d3.select(ref.current).attr('width', w).attr('height', h);
+    svg.selectAll('*').remove();
+
+    if (!data.length) {
+      svg
+        .append('text')
+        .attr('x', w / 2)
+        .attr('y', h / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#777')
+        .text('Sin datos');
+      return;
+    }
+
+    const x = d3.scaleLinear().domain(d3.extent(data)).nice().range([m, w - m]);
+
+    const kde = kernelDensityEstimator(kernelEpanechnikov(0.2), x.ticks(40));
+    const density = kde(data);
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(density, d => d[1])])
+      .nice()
+      .range([h - m, m]);
+
+    const line = d3
+      .line()
+      .curve(d3.curveBasis)
+      .x(d => x(d[0]))
+      .y(d => y(d[1]));
+
+    svg
+      .append('path')
+      .attr('d', line(density))
+      .attr('fill', 'none')
+      .attr('stroke', '#4f83cc')
+      .attr('stroke-width', 2);
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${h - m})`)
+      .call(d3.axisBottom(x).ticks(5).tickSizeOuter(0));
+
+    svg
+      .append('g')
+      .attr('transform', `translate(${m},0)`)
+      .call(d3.axisLeft(y).ticks(4).tickSizeOuter(0));
+
+    function kernelEpanechnikov(k) {
+      return v => (Math.abs((v /= k)) <= 1 ? (0.75 * (1 - v * v)) / k : 0);
+    }
+    function kernelDensityEstimator(kernel, X) {
+      return V => X.map(x => [x, d3.mean(V, v => kernel(x - v))]);
+    }
+  }, [data]);
+
+  return <svg ref={ref} role="img" aria-label="Densidad €/m²" />;
+}

--- a/alquiler-dashboard/src/components/Legend.jsx
+++ b/alquiler-dashboard/src/components/Legend.jsx
@@ -3,24 +3,21 @@ export default function Legend({ scale }) {
     const rects = scale.range();
     const max = scale.invertExtent(rects[rects.length - 1])[1];
 
-    const width = 220;
     const pad = 6;
     const step = 30;
 
     return (
       <svg
-        width={width}
-        height={40}
+        width="100%"
+        height={60}
         aria-label="leyenda"
         role="img"
         style={{ border: '1px solid #444', background: '#1e1e1e' }}
       >
         <g transform={`translate(${pad},${pad})`}>
           <text
-            x={(width - pad * 2) / 2}
-            y={0}
-            dy="0.8em"
-            fontSize={10}
+            x="50%"
+            y={14}
             textAnchor="middle"
             fill="#fff"
           >

--- a/alquiler-dashboard/src/styles/dashboard.css
+++ b/alquiler-dashboard/src/styles/dashboard.css
@@ -9,12 +9,14 @@
 body { background: var(--bg); color: var(--text); }
 h1 { font-size: clamp(1.8rem, 3vw, 2.8rem); margin: .5rem 0 1rem; }
 .grid-dash {
-  display: flex;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-template-areas:
+    "treemap   map      scatter"
+    "line      legend   scatter"
+    ".         legend   .";
+  grid-template-columns: 320px 1fr 340px;
+  grid-template-rows: auto 120px 20px;
   gap: 1rem;
-  overflow-x: auto;
-  padding: 0 1rem;
-  scroll-snap-type: x mandatory;
 }
 .card {
   background: var(--card);
@@ -23,16 +25,17 @@ h1 { font-size: clamp(1.8rem, 3vw, 2.8rem); margin: .5rem 0 1rem; }
   box-shadow: 0 1px 2px rgba(0,0,0,.6);
   padding: .75rem;
   transition: transform .2s ease, box-shadow .2s ease;
-  min-width: 340px;
-  flex: 0 0 auto;
-  scroll-snap-align: start;
+  min-width: 0;
 }
-.card:hover { transform: translateY(-4px); box-shadow:0 4px 8px rgba(0,0,0,.6);}
+.card:hover { transform: translateY(-4px); box-shadow:0 4px 8px rgba(0,0,0,.6);} 
 #tooltip {
   background: rgba(0,0,0,.8) !important;
   border: none !important;
   color: #fff !important;
 }
-
-.card.map { min-height: 500px; flex: 1 0 600px; }
+.card.treemap { grid-area: treemap; }
+.card.map { grid-area: map; min-height: 520px; }
+.card.legend { grid-area: legend; }
+.card.scatter { grid-area: scatter; }
+.card.line { grid-area: line; }
 .card.map svg { width: 100%; height: 100%; }


### PR DESCRIPTION
## Summary
- reemplaza histograma por componente `DensityLine`
- centra el mapa con nueva cuadrícula y tarjeras alrededor
- coloca la leyenda bajo el mapa y ajusta su estilo
- actualiza estilos de `dashboard.css`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a51e159248329aa1c0c3f60f2a5a8