### PR TITLE
Landing y selector de año único

### DIFF
--- a/alquiler-dashboard/src/components/DensityLine.jsx
+++ b/alquiler-dashboard/src/components/DensityLine.jsx
@@ -1,3 +1,4 @@
+/* ───── Tarjeta Densidad: distribución €/m² ───── */
 import { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 

--- a/alquiler-dashboard/src/components/Landing.jsx
+++ b/alquiler-dashboard/src/components/Landing.jsx
@@ -1,0 +1,15 @@
+/* ───── Pantalla Landing: bienvenida ───── */
+export default function Landing({ onEnter }) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <h1 className="text-4xl md:text-6xl font-bold mb-8">
+        Dashboard Alquiler&nbsp;España
+      </h1>
+      <p className="mb-6 text-center max-w-md">
+        Explora la evolución del precio medio de alquiler por provincia y
+        descubre patrones interactivos en tiempo real.
+      </p>
+      <button className="btn" onClick={onEnter}>Entrar</button>
+    </div>
+  );
+}

--- a/alquiler-dashboard/src/components/Legend.jsx
+++ b/alquiler-dashboard/src/components/Legend.jsx
@@ -1,53 +1,26 @@
+/* ───── Tarjeta Leyenda: escala de colores €/m² ───── */
 export default function Legend({ scale }) {
-  if (scale && typeof scale.invertExtent === 'function') {
-    const rects = scale.range();
-    const max = scale.invertExtent(rects[rects.length - 1])[1];
-
-    const pad = 6;
-    const step = 30;
-
-    return (
-      <svg
-        width="100%"
-        height={60}
-        aria-label="leyenda"
-        role="img"
-        style={{ border: '1px solid #444', background: '#1e1e1e' }}
-      >
-        <g transform={`translate(${pad},${pad})`}>
-          <text
-            x="50%"
-            y={14}
-            textAnchor="middle"
-            fill="#fff"
-          >
-            €/m²
-          </text>
-          {rects.map((c, i) => {
-            const [t0] = scale.invertExtent(c);
-            const x = i * step;
-            return (
-              <g key={i}>
-                <rect x={x} y={8} width={24} height={12} fill={c} />
-                <text x={x} y={24} fontSize={10} fill="#fff">
-                  {t0.toFixed ? t0.toFixed(1) : t0}
-                </text>
-              </g>
-            );
-          })}
-          <text
-            x={(rects.length - 1) * step + 24}
-            y={24}
-            fontSize={10}
-            textAnchor="end"
-            fill="#fff"
-          >
-            {max.toFixed ? max.toFixed(1) : max}
-          </text>
-        </g>
-      </svg>
-    );
-  }
-
-  return null;
+  if (!scale || typeof scale.invertExtent !== 'function') return null;
+  return (
+    <svg width="100%" height="60" aria-label="Leyenda de colores">
+      <text x="50%" y="14" textAnchor="middle" fill="#fff" fontSize="14">
+        €/m²
+      </text>
+      {scale.range().map((c, i) => (
+        <rect key={i} x={40 + i * 30} y={24} width="30" height="12" fill={c} />
+      ))}
+      {scale.range().map((c, i) => (
+        <text
+          key={i}
+          x={55 + i * 30}
+          y={50}
+          textAnchor="middle"
+          fontSize="10"
+          fill="#bbb"
+        >
+          {scale.invertExtent(c)[0].toFixed(1)}
+        </text>
+      ))}
+    </svg>
+  );
 }

--- a/alquiler-dashboard/src/components/Map.jsx
+++ b/alquiler-dashboard/src/components/Map.jsx
@@ -1,3 +1,4 @@
+/* ───── Tarjeta Mapa: alquiler medio por provincia ───── */
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import * as d3 from 'd3';
 import * as topojson from 'topojson-client';

--- a/alquiler-dashboard/src/components/Scatter.jsx
+++ b/alquiler-dashboard/src/components/Scatter.jsx
@@ -1,3 +1,4 @@
+/* ───── Tarjeta Scatter: €/m² vs índice ───── */
 import { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 

--- a/alquiler-dashboard/src/components/Treemap.jsx
+++ b/alquiler-dashboard/src/components/Treemap.jsx
@@ -1,3 +1,4 @@
+/* ───── Tarjeta Treemap: distribución superficie por CCAA ───── */
 import { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 import { hierarchy, treemap } from 'd3-hierarchy';

--- a/alquiler-dashboard/src/main.jsx
+++ b/alquiler-dashboard/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './styles/theme.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(

--- a/alquiler-dashboard/src/styles/dashboard.css
+++ b/alquiler-dashboard/src/styles/dashboard.css
@@ -1,41 +1,7 @@
-:root {
-  --bg: #131313;
-  --card: #1e1e1e;
-  --card-border: #2a2a2a;
-  --accent: #6d9fd0;
-  --text: #eaeaea;
-  font-family: system-ui, 'Inter', sans-serif;
-}
-body { background: var(--bg); color: var(--text); }
-h1 { font-size: clamp(1.8rem, 3vw, 2.8rem); margin: .5rem 0 1rem; }
-.grid-dash {
-  display: grid;
-  grid-template-areas:
-    "treemap   map      scatter"
-    "line      legend   scatter"
-    ".         legend   .";
-  grid-template-columns: 320px 1fr 340px;
-  grid-template-rows: auto 120px 20px;
-  gap: 1rem;
-}
-.card {
-  background: var(--card);
-  border: 1px solid var(--card-border);
-  border-radius: 8px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.6);
-  padding: .75rem;
-  transition: transform .2s ease, box-shadow .2s ease;
-  min-width: 0;
-}
-.card:hover { transform: translateY(-4px); box-shadow:0 4px 8px rgba(0,0,0,.6);} 
-#tooltip {
-  background: rgba(0,0,0,.8) !important;
-  border: none !important;
-  color: #fff !important;
-}
-.card.treemap { grid-area: treemap; }
-.card.map { grid-area: map; min-height: 520px; }
-.card.legend { grid-area: legend; }
-.card.scatter { grid-area: scatter; }
-.card.line { grid-area: line; }
+.dashboard-wrap   { @apply flex flex-col items-center gap-4 max-w-screen-xl mx-auto px-4 pb-8; }
+.dashboard-row    { @apply flex flex-wrap justify-center gap-4 w-full; }
+.dashboard-row>*  { flex: 1 1 320px; }
+.card.map         { flex: 1 1 600px; min-height: 520px; }
+.card.legend      { @apply w-full flex justify-center; }
+#tooltip { background: rgba(0,0,0,.8) !important; border: none !important; color: #fff !important; }
 .card.map svg { width: 100%; height: 100%; }

--- a/alquiler-dashboard/src/styles/theme.css
+++ b/alquiler-dashboard/src/styles/theme.css
@@ -1,0 +1,9 @@
+body {
+  @apply bg-zinc-900 text-zinc-200 font-sans m-0;
+}
+button.btn {
+  @apply bg-emerald-600 hover:bg-emerald-500 text-white rounded px-4 py-2;
+}
+.card {
+  @apply bg-zinc-800 rounded-xl p-4 shadow-lg;
+}


### PR DESCRIPTION
## Summary
- add landing page with welcome message
- add simple Tailwind-based theme
- switch dashboard to single-year slider
- center layout with flex utility classes
- document components with JSX comments

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a57c484d8832988f04146e26bb42e