### PR TITLE
Actualiza tablero 3x3 con mapa en el centro

### DIFF
--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -71,72 +71,67 @@ function App() {
   if (!records.length) return <p>Cargando datos…</p>;
 
   return (
-    <div className="dashboard-wrap">
-      {/* Fila 1 */}
-      <div className="dashboard-row">
-        <div
-          className="card map"
-          role="region"
-          aria-label="Mapa de alquileres por provincia"
-        >
-          <Map
-            filtered={filtered}
-            colorScaleDomain={colorDomain}
-            onSelect={setProvinciaSel}
-            selectedCca={selectedCca}
-          />
-        </div>
+    <div className="dashboard-grid">
+      {/* Línea de densidad arriba */}
+      <div className="card line">
+        {/* Muestra la distribución de €/m² en el año seleccionado */}
+        <DensityLine data={lineData} />
       </div>
 
-      {/* Slider 1 thumb centrado bajo mapa */}
-      {year != null && (
-        <input
-          type="range"
-          min={years[0]}
-          max={years.at(-1)}
-          value={year}
-          onChange={e => setYear(+e.target.value)}
-          className="w-full accent-emerald-500 mt-2"
+      {/* Treemap a la izquierda */}
+      <div className="card treemap" role="region" aria-label="Treemap por comunidad" onClick={() => setSelectedCca(null)}>
+        {/* Proporción de CCAA por superficie/alquiler */}
+        <Treemap
+          filtered={filtered}
+          selectedCca={selectedCca}
+          onSelect={setSelectedCca}
+          colorDomain={colorDomain}
         />
-      )}
-      <div className="text-center mt-1">{year}</div>
-      <button
-        onClick={() => setSelectedCca(null)}
-        disabled={!selectedCca}
-        className="btn mt-2"
-      >
-        Reset CCAA
-      </button>
+      </div>
 
-      {/* Leyenda centrada */}
+      {/* Mapa en el centro */}
+      <div className="card map" role="region" aria-label="Mapa de alquileres por provincia">
+        <Map
+          filtered={filtered}
+          colorScaleDomain={colorDomain}
+          onSelect={setProvinciaSel}
+          selectedCca={selectedCca}
+        />
+
+        {/* Selector de año bajo el mapa */}
+        {year != null && (
+          <input
+            type="range"
+            min={years[0]}
+            max={years.at(-1)}
+            value={year}
+            onChange={e => setYear(+e.target.value)}
+            className="w-full accent-emerald-500 mt-2"
+          />
+        )}
+        <div className="text-center mt-1">{year}</div>
+        <button
+          onClick={() => setSelectedCca(null)}
+          disabled={!selectedCca}
+          className="btn mt-2"
+        >
+          Reset CCAA
+        </button>
+      </div>
+
+      {/* Scatter a la derecha */}
+      <div className="card scatter">
+        {/* €/m² vs índice en el año seleccionado */}
+        <Scatter points={scatterPts} selectedCca={selectedCca} />
+      </div>
+
+      {/* Leyenda ocupa toda la fila inferior */}
       <div className="card legend">
         <Legend scale={colorScale} />
       </div>
 
-      {/* Fila 2 */}
-      <div className="dashboard-row">
-        <div
-          className="card treemap"
-          role="region"
-          aria-label="Treemap por comunidad"
-          onClick={() => setSelectedCca(null)}
-        >
-          <Treemap
-            filtered={filtered}
-            selectedCca={selectedCca}
-            onSelect={setSelectedCca}
-            colorDomain={colorDomain}
-          />
-        </div>
-        <div className="card scatter">
-          <Scatter points={scatterPts} selectedCca={selectedCca} />
-        </div>
-        <div className="card line">
-          <DensityLine data={lineData} />
-        </div>
-      </div>
       {provinciaSel && (
-        <footer className="mt-2">Provincia seleccionada: {provinciaSel}</footer>
+        <footer className="mt-2 col-span-full text-center">Provincia seleccionada: {provinciaSel}</footer>
       )}
     </div>
   );

--- a/alquiler-dashboard/src/components/Legend.jsx
+++ b/alquiler-dashboard/src/components/Legend.jsx
@@ -2,21 +2,21 @@
 export default function Legend({ scale }) {
   if (!scale || typeof scale.invertExtent !== 'function') return null;
   return (
-    <svg width="100%" height="60" aria-label="Leyenda de colores">
-      <text x="50%" y="14" textAnchor="middle" fill="#fff" fontSize="14">
+    <svg width="100%" height="70">
+      <text x="50%" y="16" textAnchor="middle" fontSize="16" fill="#fff">
         €/m²
       </text>
       {scale.range().map((c, i) => (
-        <rect key={i} x={40 + i * 30} y={24} width="30" height="12" fill={c} />
+        <rect key={i} x={60 + i * 40} y={28} width="40" height="14" fill={c} />
       ))}
       {scale.range().map((c, i) => (
         <text
           key={i}
-          x={55 + i * 30}
-          y={50}
+          x={80 + i * 40}
+          y={60}
           textAnchor="middle"
           fontSize="10"
-          fill="#bbb"
+          fill="#ccc"
         >
           {scale.invertExtent(c)[0].toFixed(1)}
         </text>

--- a/alquiler-dashboard/src/styles/dashboard.css
+++ b/alquiler-dashboard/src/styles/dashboard.css
@@ -1,7 +1,37 @@
-.dashboard-wrap   { @apply flex flex-col items-center gap-4 max-w-screen-xl mx-auto px-4 pb-8; }
-.dashboard-row    { @apply flex flex-wrap justify-center gap-4 w-full; }
-.dashboard-row>*  { flex: 1 1 320px; }
-.card.map         { flex: 1 1 600px; min-height: 520px; }
-.card.legend      { @apply w-full flex justify-center; }
+.dashboard-grid {
+  display: grid;
+  grid-template-areas:
+    "line   line    line"
+    "tree   map     scat"
+    "legend legend  legend";
+  grid-template-columns: 320px 1fr 340px;    /* izq, centro, dcha */
+  grid-template-rows:   160px auto  90px;    /* arriba, centro, abajo */
+  gap: 1rem;
+  max-width: 1400px;       /* no sobrepasar pantallas muy anchas */
+  margin: 0 auto;          /* centrado */
+  padding: 1rem;
+}
+
+.card.map    { grid-area: map;    min-height: 550px; }
+.card.line   { grid-area: line;   }
+.card.treemap{ grid-area: tree;   }
+.card.scatter{ grid-area: scat;   }
+.card.legend { grid-area: legend; display:flex; justify-content:center; align-items:center; }
+
 #tooltip { background: rgba(0,0,0,.8) !important; border: none !important; color: #fff !important; }
 .card.map svg { width: 100%; height: 100%; }
+
+@media (max-width: 900px) {
+  /* Apilar en móvil */
+  .dashboard-grid {
+    grid-template-areas:
+      "map"
+      "line"
+      "tree"
+      "scat"
+      "legend";
+    grid-template-columns: 1fr;
+    grid-template-rows:   auto;
+  }
+  .card { min-width: 0; }
+}


### PR DESCRIPTION
## Summary
- crea un layout en cuadrícula 3×3 con CSS puro
- actualiza `App.jsx` con comentarios JSX y slider dentro de la tarjeta mapa
- centra la leyenda y ajusta dimensiones

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a5b98fdb483298dce42de05bae434