### PR TITLE
Drop headlessui and add custom Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # PruebaCodex
+
+Reemplazado Headless UI por un componente Tabs propio para evitar conflicto de peer-dependencies con React 19.

--- a/alquiler-dashboard/README.md
+++ b/alquiler-dashboard/README.md
@@ -36,3 +36,4 @@ Leyenda muestra €/m² y treemap etiqueta CCAA.
 
 Las visualizaciones usan D3 en React.
 No se emplea Vega/Altair; migrar un gráfico a Vega-Lite (p.ej. con react-vega) sería una mejora futura.
+Reemplazado Headless UI por un componente Tabs propio para evitar conflicto de peer-dependencies con React 19.

--- a/alquiler-dashboard/package.json
+++ b/alquiler-dashboard/package.json
@@ -19,8 +19,7 @@
     "react-dom": "^19.1.0",
     "react-range": "^1.10.0",
     "topojson-client": "^3.1.0",
-    "csv-parse": "^5.5.4",
-    "@headlessui/react": "^1.7.18"
+    "csv-parse": "^5.5.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/alquiler-dashboard/src/App.jsx
+++ b/alquiler-dashboard/src/App.jsx
@@ -6,8 +6,6 @@ import Map from './components/Map';
 import Header from './components/Header';
 import Treemap from './components/Treemap';
 import TabsPanel from './components/TabsPanel';
-import Scatter from './components/Scatter';
-import DensityLine from './components/DensityLine';
 import './styles/dashboard.css';
 import useAlquilerEuros from './hooks/useAlquilerEuros';
 import useIndiceData from './hooks/useIndiceData';

--- a/alquiler-dashboard/src/components/Tabs.js
+++ b/alquiler-dashboard/src/components/Tabs.js
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+/* Minimal Tabs – compatible con cualquier versión de React
+Props:
+  labels: string[]
+  panels: React.ReactNode[] (mismo orden)
+*/
+export default function Tabs({ labels, panels }) {
+  const [idx, setIdx] = useState(0);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* barra de pestañas */}
+      <div className="flex space-x-2 mb-2">
+        {labels.map((lab, i) => (
+          <button
+            key={lab}
+            className={`px-3 py-1 rounded text-sm ${
+              i === idx ? 'bg-emerald-600' : 'bg-zinc-700 hover:bg-zinc-600'
+            }`}
+            onClick={() => setIdx(i)}
+          >
+            {lab}
+          </button>
+        ))}
+      </div>
+
+      {/* panel activo */}
+      <div className="flex-1 overflow-hidden">{panels[idx]}</div>
+    </div>
+  );
+}

--- a/alquiler-dashboard/src/components/TabsPanel.jsx
+++ b/alquiler-dashboard/src/components/TabsPanel.jsx
@@ -1,34 +1,17 @@
-import { Tab } from '@headlessui/react';
+import Tabs from './Tabs';
 import ParallelChart from './ParallelChart';
 import Scatter from './Scatter';
 import DensityLine from './DensityLine';
 
 export default function TabsPanel({ serieParalelo, serieScatter, serieDens }) {
   return (
-    <Tab.Group>
-      <Tab.List className="flex space-x-2 mb-2">
-        {['Paralelo', 'Scatter', 'Densidad'].map(txt => (
-          <Tab
-            key={txt}
-            className={({ selected }) =>
-              `px-3 py-1 rounded ${selected ? 'bg-emerald-600' : 'bg-zinc-700'} text-sm`
-            }
-          >
-            {txt}
-          </Tab>
-        ))}
-      </Tab.List>
-      <Tab.Panels className="flex-1">
-        <Tab.Panel>
-          <ParallelChart data={serieParalelo} />
-        </Tab.Panel>
-        <Tab.Panel>
-          <Scatter data={serieScatter} />
-        </Tab.Panel>
-        <Tab.Panel>
-          <DensityLine data={serieDens} />
-        </Tab.Panel>
-      </Tab.Panels>
-    </Tab.Group>
+    <Tabs
+      labels={['Paralelo', 'Scatter', 'Densidad']}
+      panels={[
+        <ParallelChart key="par" data={serieParalelo} />,
+        <Scatter key="sca" data={serieScatter} />,
+        <DensityLine key="den" data={serieDens} />,
+      ]}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- remove `@headlessui/react` dependency
- implement a small `Tabs` helper
- refactor `TabsPanel` to use the new component
- update README notes about the change

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b25a0d8ec83298f13414f15abd9ff